### PR TITLE
Remove the dependency on lager

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,17 +12,13 @@
   warn_unused_function,
   warn_unused_record,
   warn_unused_vars,
-  debug_info,
-  {parse_transform, lager_transform}
+  debug_info
  ]}.
 
 {cover_enabled, true}.
 
 {deps,
- [{lager,
-   {git, "https://github.com/erlang-lager/lager.git",
-    {tag, "3.4.1"}}}
- ]}.
+ []}.
 
 {profiles, [
     {test, [

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -199,6 +199,9 @@ complete_value(Path, Ctx, Ty, Fields, {ok, {enum, Value}}) ->
 complete_value(Path, Ctx, {scalar, Scalar}, Fields, {ok, Value}) ->
     complete_value(Path, Ctx, output_coerce_type(Scalar), Fields, {ok, Value});
 complete_value(Path, Ctx, Ty, Fields, {ok, Value}) when is_binary(Ty) ->
+    error_logger:warning_msg(
+      "Canary: Type lookup during value completion for: ~p",
+      [Ty]),
     SchemaType = graphql_schema:get(Ty),
     complete_value(Path, Ctx, SchemaType, Fields, {ok, Value});
 complete_value(Path, Ctx, {non_null, InnerTy}, Fields, Result) ->

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -200,7 +200,7 @@ complete_value(Path, Ctx, {scalar, Scalar}, Fields, {ok, Value}) ->
     complete_value(Path, Ctx, output_coerce_type(Scalar), Fields, {ok, Value});
 complete_value(Path, Ctx, Ty, Fields, {ok, Value}) when is_binary(Ty) ->
     error_logger:warning_msg(
-      "Canary: Type lookup during value completion for: ~p",
+      "Canary: Type lookup during value completion for: ~p~n",
       [Ty]),
     SchemaType = graphql_schema:get(Ty),
     complete_value(Path, Ctx, SchemaType, Fields, {ok, Value});
@@ -233,8 +233,8 @@ complete_value(Path, _Ctx, #scalar_type { id = ID, output_coerce = OCoerce, reso
     catch
         Cl:Err ->
             error_logger:error_msg(
-              "Output coercer crash: ~p, stack: ~p",
-              [{Cl,Err}, erlang:get_stacktrace()]),
+              "Output coercer crash during value completion: ~p, stacktrace: ~p~n",
+              [{Cl,Err,ID,Value}, erlang:get_stacktrace()]),
             err(Path, {coerce_crash, ID, Value, {Cl, Err}})
     end;
 complete_value(Path, _Ctx, #scalar_type { id = ID, resolve_module = RM }, _Fields, {ok, Value}) ->
@@ -245,7 +245,7 @@ complete_value(Path, _Ctx, #scalar_type { id = ID, resolve_module = RM }, _Field
     catch
         Cl:Err ->
             error_logger:error_msg(
-              "Output coercer crash: ~p, stack: ~p",
+              "Output coercer crash during value completion: ~p, stacktrace: ~p~n",
               [{Cl,Err,ID,Value}, erlang:get_stacktrace()]),
             err(Path, {coerce_crash, ID, Value, {Cl, Err}})
     end;
@@ -282,8 +282,8 @@ resolve_abstract_type(Resolver, Value) when is_function(Resolver, 1) ->
     catch
        Cl:Err ->
             error_logger:error_msg(
-              "Resolve_type crashed: ~p",
-              [erlang:get_stacktrace()]),
+              "Type resolver crashed: ~p stacktrace: ~p~n",
+              [{Cl,Err}, erlang:get_stacktrace()]),
            {error, {resolve_type_crash, {Cl,Err}}}
     end.
 

--- a/src/graphql_schema.erl
+++ b/src/graphql_schema.erl
@@ -6,12 +6,12 @@
 
 -export([start_link/0, reset/0]).
 -export([
-	all/0,
-	insert/1, insert/2,
-	load/1,
-	get/1,
-	lookup/1,
-	lookup_enum_type/1]).
+    all/0,
+    insert/1, insert/2,
+    load/1,
+    get/1,
+    lookup/1,
+    lookup_enum_type/1]).
 -export([resolve_root_type/2]).
 
 -export([id/1]).
@@ -54,8 +54,8 @@ insert(S, #{ canonicalize := true }) ->
     catch
         Class:Reason ->
             error_logger:error_msg(
-              "Schema canonicalization error: ~p",
-              [erlang:get_stacktrace()]),
+              "Schema canonicalization error: ~p stacktrace: ~p~n",
+              [{Class,Reason}, erlang:get_stacktrace()]),
             {error, {schema_canonicalize, {Class, Reason}}}
     end;
 insert(S, #{}) ->
@@ -131,8 +131,8 @@ init([]) ->
          [named_table, protected, {read_concurrency, true}, set,
            {keypos, 1}]),
     _Tab = ets:new(?OBJECTS,
-    	[named_table, protected, {read_concurrency, true}, set,
-    	 {keypos, #object_type.id}]),
+        [named_table, protected, {read_concurrency, true}, set,
+         {keypos, #object_type.id}]),
     {ok, #state{}}.
 
 -spec handle_cast(any(), S) -> {noreply, S}

--- a/src/graphql_schema.erl
+++ b/src/graphql_schema.erl
@@ -53,7 +53,9 @@ insert(S, #{ canonicalize := true }) ->
             end
     catch
         Class:Reason ->
-            lager:warning("Schema canonicalization error: ~p", [erlang:get_stacktrace()]),
+            error_logger:error_msg(
+              "Schema canonicalization error: ~p",
+              [erlang:get_stacktrace()]),
             {error, {schema_canonicalize, {Class, Reason}}}
     end;
 insert(S, #{}) ->

--- a/src/graphql_schema_parse.erl
+++ b/src/graphql_schema_parse.erl
@@ -92,11 +92,11 @@ mk(#{ interfaces := IF }, #p_interface {
        annotations => annotations(Annots),
        fields => Fields
       }}.
-          
+
 fields(Raw) ->
     maps:from_list([field(R) || R <- Raw]).
 
-input_defs(Raw) ->  
+input_defs(Raw) ->
     maps:from_list([input_def(D) || D <- Raw]).
 
 inject(Def) ->
@@ -113,7 +113,7 @@ schema_defn(_) -> false.
 report_other_entries([]) -> ok;
 report_other_entries(Es) ->
     error_logger:error_msg("Loading graphql schema from file, "
-                           "but it contains non-schema entries: ~p",
+                           "but it contains non-schema entries: ~p~n",
                            [Es]),
     ok.
 
@@ -130,15 +130,15 @@ binarize(default) -> default;
 binarize(A) when is_atom(A) -> atom_to_binary(A, utf8).
 
 name({name, _, N}) -> N.
-    
+
 annotations(As) ->
     maps:from_list([annotation(A) || A <- As]).
 
 annotation(#annotation { id = {name, _, T}, args = Args }) ->
     {T, maps:from_list([annotation_arg(Ag) || Ag <- Args])}.
-    
+
 annotation_arg({{name, _, A}, Val}) -> {A, Val}.
-       
+
 description(Annots) ->
     case find(<<"description">>, Annots) of
         not_found ->
@@ -149,7 +149,7 @@ description(Annots) ->
 
 input_def(#p_input_value { id = ID,
                            annotations = Annots,
-                           default = Default, 
+                           default = Default,
                            type = Type }) ->
     Name = name(ID),
     Description = description(Annots),
@@ -186,7 +186,7 @@ variants(Vs) ->
                 {K, #{ value => I, description => "No descriptions supported yet" }}
         end,
     maps:from_list(mapi(F, Vs)).
-                
+
 mapi(F, L) -> mapi(F, L, 0).
 
 mapi(_F, [], _) -> [];
@@ -208,4 +208,3 @@ mapping(Name, Map) ->
             maps:get(default, Map);
         X -> X
     end.
-            

--- a/src/graphql_schema_parse.erl
+++ b/src/graphql_schema_parse.erl
@@ -112,7 +112,9 @@ schema_defn(_) -> false.
 
 report_other_entries([]) -> ok;
 report_other_entries(Es) ->
-    lager:warning("Loading graphql schema from file, but it contains non-schema entries: ~p", [Es]),
+    error_logger:error_msg("Loading graphql schema from file, "
+                           "but it contains non-schema entries: ~p",
+                           [Es]),
     ok.
 
 handle_mapping(Map) ->


### PR DESCRIPTION
We replace lager with the built-in error logger. It strips off the
lager dependency and we don't need that since the error logger can do
its job. Furthermore, lager will pick up the error logger messages
anyway and transform them in the system, so we don't lose anything by
doing this.

The change brings the dependencies from 1 to 0.

Reported-By: @goertzenator -- who noted that GraphQL is 0.38megabyte
in size whereas lager is close to 2megabyte.