### PR TITLE
fix application boot: remove lager definitely

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_opts, 
+{erl_opts,
  [warn_bif_clash,
   warn_deprecated_function,
   warn_export_all,
@@ -22,7 +22,7 @@
 
 {profiles, [
     {test, [
-        {deps, [{jsx, {git, "https://github.com/talentdeficit/jsx.git", {branch, "2.8.0"}}}
+            {deps, [{jsx, {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}}
         ]}
     ]}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,1 @@
-[{<<"goldrush">>,
-  {git,"https://github.com/DeadZen/goldrush.git",
-       {ref,"8f1b715d36b650ec1e1f5612c00e28af6ab0de82"}},
-  1},
- {<<"lager">>,
-  {git,"https://github.com/erlang-lager/lager.git",
-       {ref,"92b1548f7f97a7fef257dffc45ef7b14006334e6"}},
-  0}].
+[].

--- a/src/graphql.app.src
+++ b/src/graphql.app.src
@@ -4,8 +4,7 @@
   {registered, []},
   {applications,
    [kernel,
-    stdlib,
-    lager
+    stdlib
    ]},
   {mod, {graphql_app, []}},
   {env,[]},


### PR DESCRIPTION
lager was still part of the app.src and rebar.lock. This PR remove it. While i'm here i fixed the jsx dependency line in rebar.config to use `tag` instead of `branch` 