### PR TITLE
Fix the order of the path when an error is encountered

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -268,7 +268,7 @@ complete_value(Path, Ctx, #object_type{} = Ty, Fields, {ok, Value}) ->
     {Result, Errs} = execute_sset(Path, Ctx, SubSelectionSet, Ty, Value),
     {ok, Result, Errs};
 complete_value(Path, _Ctx, _Ty, _Fields, {error, Reason}) ->
-    {ok, null, [#{ path => Path, reason => Reason }]}.
+    {ok, null, [#{ path => lists:reverse(Path), reason => Reason }]}.
 
 resolve_abstract_type(Module, Value) when is_atom(Module) ->
     resolve_abstract_type(fun Module:execute/1, Value);


### PR DESCRIPTION
When an error is encountered the path information seems to be in reversed order. This is the current behavior:

```
{
  "data": { "node": null },
  "errors": [
    {
      "path": [
        "node",
        "NodeQuery"
      ],
      "reason": "not_found"
    }
  ]
}
```

This patch should result in this:

```
{
  "data": { "node": null },
  "errors": [
    {
      "path": [
        "NodeQuery",
        "node"
      ],
      "reason": "not_found"
    }
  ]
}
```