### PR TITLE
Fix elaborator type names

### DIFF
--- a/src/graphql_ast.erl
+++ b/src/graphql_ast.erl
@@ -53,5 +53,6 @@ id(E) ->
 id_(#op { id = ID }) -> ID;
 id_(#field { id = ID }) -> ID;
 id_(#frag_spread { id = ID }) -> ID;
-id_(#frag { id = ID }) -> ID.
-
+id_(#frag { id = ID }) -> ID;
+id_(#vardef { id = ID }) -> ID.
+     

--- a/src/graphql_elaborate.erl
+++ b/src/graphql_elaborate.erl
@@ -79,7 +79,7 @@ op(Path, #op { vardefs = VDefs, directives = [] } = Op) ->
     RootSchema = root(Path, Op),
     case graphql_schema:lookup(RootSchema) of
         not_found ->
-            graphql_err:abort([Op | Path], {type_not_found, RootSchema});
+            graphql_err:abort([Op | Path], {type_not_found, graphql_ast:name(RootSchema)});
         #object_type{ fields = Fields } = Obj ->
             fields([Op | Path], Op#op{ schema = Obj, vardefs = var_defs([Op | Path], VDefs) }, Fields)
     end;
@@ -112,7 +112,7 @@ vdef_type(N) when is_binary(N) ->
 
 var_defs(Path, VDefs) ->
     [case vdef(V) of
-        not_found -> graphql_err:abort(Path, {type_not_found, V});
+        not_found -> graphql_err:abort(Path, {type_not_found, graphql_ast:id(V)});
         {invalid_input_type, T} -> graphql_err:abort(Path, {not_input_type, T});
         Ty -> V#vardef { ty = Ty }
       end || V <- VDefs].


### PR DESCRIPTION
If a type name is not found, do not output the structure, but send the
failing ID along to the graph_err path. This ought to fix some
problems where an error that is client-side is incorrectly registered
as server side.