### PR TITLE
Fix GetOperation for parameterized operation calls

### DIFF
--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -62,7 +62,8 @@ groups() ->
                  nested_field_merge,
                  multiple_monsters_and_rooms,
                  include_directive,
-                 introspection
+                 introspection,
+                 get_operation
                  ]},
 
     Errors = {errors, [],
@@ -113,6 +114,18 @@ introspection(Config) ->
         #{ } ->
             ok %% No Errors present, so this is OK
     end.
+
+get_operation(Config) ->
+    GoblinId = base64:encode(<<"monster:1">>),
+    Expected = #{ data => #{<<"monster">> => #{ <<"name">> => <<"goblin">> }}},
+    Q1 = "{ monster(id: \"" ++ binary_to_list(GoblinId) ++ "\") { name }}",
+    Expected = th:x(Config, Q1),
+    Q2 = "query Q { monster(id: \"" ++ binary_to_list(GoblinId) ++ "\") { name }}",
+    Expected = th:x(Config, Q2),
+    Q3 = "query Q($id : ID!) { monster(id: $id) { name }}",
+    Expected = th:x(Config, Q3, <<"Q">>, #{ <<"id">> => GoblinId }),
+    Expected = th:x(Config, Q3, #{ <<"id">> => GoblinId }),
+    ok.
 
 include_directive(Config) ->
     GoblinID = base64:encode(<<"monster:1">>),


### PR DESCRIPTION
The variant where your query has a single operation with parameters
was not handled correctly. It was rejected, but the spec says it
should be accepted.

The problem is in the type checking phase for parameters. It didn't
account for this particular case correctly, so you obtained the empty
map as the parameters list. This of course breaks deep down in the
execution code since it assumes all parameters have been correctly
checked.

The fix is to analyze the environment and if there is a single
operation, with no "OpName" given, then assume it is *the* operation
to execute.

It also makes @lozhuf happy :)