### PR TITLE
Jl/feature/list result error reporting

### DIFF
--- a/src/graphql_ast.erl
+++ b/src/graphql_ast.erl
@@ -5,7 +5,7 @@
 
 -export([resolve_type/1, unwrap_to_base_type/1]).
 -export([unwrap_type/1]).
--export([name/1, id/1]).
+-export([name/1, id/1, typename/1]).
 
 -spec resolve_type(graphql_type()) -> tycond().
 resolve_type({scalar, Sc}) -> {scalar, Sc};
@@ -56,3 +56,10 @@ id_(#frag_spread { id = ID }) -> ID;
 id_(#frag { id = ID }) -> ID;
 id_(#vardef { id = ID }) -> ID.
      
+typename(#enum_type { id = ID }) -> ID;
+typename(#interface_type { id = ID }) -> ID;
+typename(#union_type { id = ID }) -> ID;
+typename(#scalar_type { id = ID }) -> ID;
+typename(#input_object_type { id = ID }) -> ID;
+typename(#object_type { id = ID }) -> ID.
+

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -45,6 +45,8 @@ type Monster implements Node {
   statsVariantTwo : [Stats!]
   statsVariantThree : [Stats!]!
   properties : [Property]
+
+  errorListResolution : [Property]
 }
 
 type Room implements Node {

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -26,7 +26,10 @@ execute(_Ctx, #monster { id = ID,
         <<"statsVariantTwo">> -> stats(Stats);
         <<"statsVariantThree">> -> stats(Stats);
         <<"properties">> ->
-            {ok, [{ok, P} || P <- Properties]}
+            {ok, [{ok, P} || P <- Properties]};
+        <<"errorListResolution">> ->
+            %% This produces a wrong return on purpose
+            {ok, [<<"MECH">>, <<"DRAGON">>]}
     end.
 
 color(Color, #{ <<"colorType">> := <<"rgb">> }) ->


### PR DESCRIPTION
Support an assertion on array types which can be useful to the GraphQL backend developer: the mistake is commonly made and we can weed it out by checking for it in the return value inside the engine.