### PR TITLE
Allow integers in floating point context. Closes #50

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -443,10 +443,12 @@ output_coerce_type(int) ->
         (_) -> {ok, null}
       end };
 output_coerce_type(float) ->
-    #scalar_type { id = float, output_coerce = fun
-        (F) when is_float(F) -> {ok, F};
-        (_) -> {ok, null}
-      end };
+    Coercer = fun
+                  (F) when is_float(F) -> {ok, F};
+                  (I) when is_integer(I) -> {ok, float(I)};
+                  (_) -> {ok, null}
+              end,
+    #scalar_type { id = float, output_coerce = Coercer };
 output_coerce_type(#scalar_type{} = SType) -> SType;
 output_coerce_type(UserDefined) when is_binary(UserDefined) ->
     case graphql_schema:lookup(UserDefined) of
@@ -530,6 +532,7 @@ value_scalar(bool, false) -> false;
 value_scalar(int, I) when is_integer(I) -> I;
 value_scalar(int, null) -> null;
 value_scalar(float, F) when is_float(F) -> F;
+value_scalar(float, I) when is_integer(I) -> float(I);
 value_scalar(float, null) -> null;
 value_scalar(Ty, V) ->
     error_logger:error_msg(

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -65,7 +65,8 @@ groups() ->
                  multiple_monsters_and_rooms,
                  include_directive,
                  introspection,
-                 get_operation
+                 get_operation,
+                 coercion_int_float
                  ]},
 
     Errors = {errors, [],
@@ -135,6 +136,13 @@ duplicate_validation(Config) ->
     GoblinId = base64:encode(<<"monster:1">>),
     Q1 = "query Q { monster(id: \"" ++ binary_to_list(GoblinId) ++ "\") { name }} ",    
     #{ errors := _} = th:x(Config, Q1 ++ Q1),
+    ok.
+
+coercion_int_float(Config) ->
+    GoblinId = ?config(goblin_id, Config),
+    Expected = #{ data => #{<<"monster">> => #{ <<"spikyness">> => 5.0 }}},
+    Q1 = "{ monster(id: \"" ++ binary_to_list(GoblinId) ++ "\") { spikyness }}",
+    Expected = th:x(Config, Q1),
     ok.
 
 get_operation(Config) ->

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -40,6 +40,7 @@ type Monster implements Node {
   hp : Int!
   mood : Mood
   plushFactor : Float!
+  spikyness : Float
   stats(minAttack: Int = 0) : [Stats]
   statsVariantOne : [Stats]!
   statsVariantTwo : [Stats!]

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -21,6 +21,7 @@ execute(_Ctx, #monster { id = ID,
         <<"inventory">> -> {ok, [dungeon:load(OID) || OID <- Inventory]};
         <<"mood">> -> {ok, Mood};
         <<"plushFactor">> -> {ok, PlushFactor};
+        <<"spikyness">> -> {ok, 5};
         <<"stats">> -> stats(Stats, Args);
         <<"statsVariantOne">> -> stats(Stats);
         <<"statsVariantTwo">> -> stats(Stats);


### PR DESCRIPTION
If the Schema expects a float but you have an integer, we convert the
integer to a float and use that instead as the output. There are some
caveats to doing this, but I think we are better served by doing it.

* Floating points can only represent certain integers precisely.
  Otherwise they become approximate. But since the context is a float
  anyway, there is no loss of precision client-wise.

* Erlang systems can at times produce integers in FP contexts because
  the language is dynamically typed and you write with "numbers" in
  some situations.

* The danger of doing this is that there may be situations in which
  the programmer never intended an integer but gets one anyway. You
  can assert this in your own executor if you need this functionality.
  Alternatively, you can create your own scalar and use that.