### PR TITLE
Jl/feature/improve error handling

### DIFF
--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -28,14 +28,20 @@
 -type schema_field() :: #{ atom() => any() }.
 -export_type([schema_field/0]).
 
--spec parse( binary() | string()) -> {ok, ast()} | {error, term()}.
+-spec parse( binary() | string()) ->
+                   {ok, ast()} | {error, {scanner_error | parser_error, term()}}.
 parse(Input) when is_binary(Input) -> parse(binary_to_list(Input));
 parse(Input) when is_list(Input) ->
     case graphql_scanner:string(Input) of
         {ok, Tokens, _EndLine} ->
-            graphql_parser:parse(Tokens);
+            case graphql_parser:parse(Tokens) of
+                {ok, Res} ->
+                    {ok, Res};
+                {error, Err} ->
+                    {error, {parser_error, Err}}
+            end;
         {error, Err, _EndLine} ->
-            {error, Err}
+            {error, {scanner_error, Err}}
     end.
 
 load_schema(Mapping, Input) when is_binary(Input) ->

--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -20,16 +20,15 @@ abort(Path, Phase, Msg) ->
    throw({error, Err}).
 
 %% -- Error handling dispatch to the module responsible for the error
-err_msg({elaborate, Reason}) ->
-    graphql_elaborate:err_msg(Reason);
-err_msg({type_check, Reason}) ->
-    graphql_type_check:err_msg(Reason);
-err_msg({uncategorized, Reason}) ->
-    err_uncategorized(Reason).
+err_msg({elaborate, Reason})     -> graphql_elaborate:err_msg(Reason);
+err_msg({type_check, Reason})    -> graphql_type_check:err_msg(Reason);
+err_msg({validate, Reason})      -> graphql_validate:err_msg(Reason);
+err_msg({uncategorized, Reason}) -> err_uncategorized(Reason).
 
-err_key(type_check, Key) -> Key;
-err_key(elaborate, Key) -> Key;
-err_key(uncategorized, Key) -> Key.
+err_key(type_check, Key)    -> Key;
+err_key(elaborate, Key)     -> Key;
+err_key(uncategorized, Key) -> Key;
+err_key(validate, Key)      -> Key.
 
 err_uncategorized({unknown_type, Ty}) ->
     ["Unknown type: ", Ty];

--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -5,6 +5,7 @@
 
 -export([abort/2, abort/3]).
 -export([path/1]).
+-export([format_ty/1]).
 
 abort(Path, Msg) ->
     abort(Path, uncategorized, Msg).
@@ -21,51 +22,24 @@ abort(Path, Phase, Msg) ->
 %% -- Error handling dispatch to the module responsible for the error
 err_msg({elaborate, Reason}) ->
     graphql_elaborate:err_msg(Reason);
+err_msg({type_check, Reason}) ->
+    graphql_type_check:err_msg(Reason);
 err_msg({uncategorized, Reason}) ->
     err_uncategorized(Reason).
 
-err_key(elaborate, Key) ->
-    Key;
-err_key(uncategorized, Key) ->
-    Key.
+err_key(type_check, Key) -> Key;
+err_key(elaborate, Key) -> Key;
+err_key(uncategorized, Key) -> Key.
 
-err_uncategorized({unknown_fragment, F}) ->
-    ["Unknown fragment: ", F];
 err_uncategorized({unknown_type, Ty}) ->
     ["Unknown type: ", Ty];
-err_uncategorized({unknown_enum, E}) ->
-    ["The enum name ", E, " is not known to the schema"];
 err_uncategorized({not_unique, Op}) ->
     ["The operation name ",
      Op, " occurs more than once in query document"];
-err_uncategorized({type_mismatch, #{ id := ID, document := Doc, schema := Sch }}) ->
-    ["Type mismatch on (", ID, "). The query document has a value/variable of type (",
-      format_ty(Doc), ") but the schema expects type (", format_ty(Sch), ")"];
-err_uncategorized({type_mismatch, #{ schema := Sch }}) ->
-    ["Type mismatch, expected (", format_ty(Sch), ")"];
-err_uncategorized({enum_not_found, Ty, Val}) ->
-    X = io_lib:format("The value ~p is not a valid enum value for type ", [Val]),
-    [X, format_ty(Ty)];
-err_uncategorized({param_mismatch, Ty, _}) ->
-    ["Parameter is not of type ", format_ty(Ty)];
 err_uncategorized({unknown_enum_type, Val}) ->
     ["The value ", Val, " does not belong to any enum type known to the schema"];
-err_uncategorized({operation_not_found, Op}) ->
-    ["Expected an operation ", Op, " but no such operation was found"];
-err_uncategorized(params_on_unnamed) ->
-    ["Cannot supply parameter lists to unnamed (anonymous) queries"];
 err_uncategorized({selection_on_enum_type, Ty}) ->
     ["Cannot apply a selection set on the enum type ", format_ty(Ty)];
-err_uncategorized(missing_non_null_param) ->
-    ["The parameter is non-null, but was undefined in parameter list"];
-err_uncategorized({unbound_variable, Var}) ->
-    ["The document refers to a variable ", Var, " but no such var exists. Perhaps the variable is a typo?"];
-err_uncategorized({input_coerce_abort, {Class, Reason}}) ->
-    io_lib:format("Input coercer failed with an exception of class ~p and reason ~p", [Class, Reason]);
-err_uncategorized({input_coercion, Type, Value, Reason}) ->
-    io_lib:format("Input coercion failed for type ~s with value ~p. The reason it failed is: ~p", [Type, Value, Reason]);
-err_uncategorized({excess_fields_in_object, Fields}) ->
-    io_lib:format("The object contains unknown fields and values: ~p", [Fields]);
 err_uncategorized(Otherwise) ->
     io_lib:format("General uncategorized error: ~p", [Otherwise]).
 

--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -3,70 +3,70 @@
 -include("graphql_internal.hrl").
 -include("graphql_schema.hrl").
 
--export([abort/2]).
+-export([abort/2, abort/3]).
 -export([path/1]).
 
--spec abort([any()], any()) -> no_return().
 abort(Path, Msg) ->
+    abort(Path, uncategorized, Msg).
+
+-spec abort([any()], any()) -> no_return().
+abort(Path, Phase, Msg) ->
    Err = #{
       path => path(lists:reverse(Path)),
-      key => Msg,
-      message => iolist_to_binary(err_msg(Msg))
+      key => err_key(Phase, Msg),
+      message => iolist_to_binary(err_msg({Phase, Msg}))
    },
    throw({error, Err}).
 
-err_msg({type_not_found, Ty}) ->
-    ["Type not found in schema: ", Ty];
-err_msg(no_root_schema) ->
-    ["No root schema found"];
-err_msg({entity_not_found, Ty}) ->
-    ["Unknown object/interface: ", Ty];
-err_msg({unknown_fragment, F}) ->
+%% -- Error handling dispatch to the module responsible for the error
+err_msg({elaborate, Reason}) ->
+    graphql_elaborate:err_msg(Reason);
+err_msg({uncategorized, Reason}) ->
+    err_uncategorized(Reason).
+
+err_key(elaborate, Key) ->
+    Key;
+err_key(uncategorized, Key) ->
+    Key.
+
+err_uncategorized({unknown_fragment, F}) ->
     ["Unknown fragment: ", F];
-err_msg({unknown_field, F}) ->
-    ["Unknown field: ", F];
-err_msg({unknown_type, Ty}) ->
+err_uncategorized({unknown_type, Ty}) ->
     ["Unknown type: ", Ty];
-err_msg(selection_on_scalar) ->
-    ["Cannot apply a selection set to a scalar field"];
-err_msg({unknown_enum, E}) ->
+err_uncategorized({unknown_enum, E}) ->
     ["The enum name ", E, " is not known to the schema"];
-err_msg({not_unique, Op}) ->
+err_uncategorized({not_unique, Op}) ->
     ["The operation name ",
      Op, " occurs more than once in query document"];
-err_msg(fieldless_object) ->
-    ["The path refers to an Object, but no fields were specified"];
-err_msg({type_mismatch, #{ id := ID, document := Doc, schema := Sch }}) ->
+err_uncategorized({type_mismatch, #{ id := ID, document := Doc, schema := Sch }}) ->
     ["Type mismatch on (", ID, "). The query document has a value/variable of type (",
       format_ty(Doc), ") but the schema expects type (", format_ty(Sch), ")"];
-err_msg({type_mismatch, #{ schema := Sch }}) ->
+err_uncategorized({type_mismatch, #{ schema := Sch }}) ->
     ["Type mismatch, expected (", format_ty(Sch), ")"];
-err_msg({enum_not_found, Ty, Val}) ->
+err_uncategorized({enum_not_found, Ty, Val}) ->
     X = io_lib:format("The value ~p is not a valid enum value for type ", [Val]),
     [X, format_ty(Ty)];
-err_msg({param_mismatch, Ty, _}) ->
+err_uncategorized({param_mismatch, Ty, _}) ->
     ["Parameter is not of type ", format_ty(Ty)];
-err_msg({unknown_enum_type, Val}) ->
+err_uncategorized({unknown_enum_type, Val}) ->
     ["The value ", Val, " does not belong to any enum type known to the schema"];
-err_msg(fieldless_interface) ->
-    ["The path refers to an Interface, but no fields were specified"];
-err_msg({operation_not_found, Op}) ->
+err_uncategorized({operation_not_found, Op}) ->
     ["Expected an operation ", Op, " but no such operation was found"];
-err_msg(params_on_unnamed) ->
+err_uncategorized(params_on_unnamed) ->
     ["Cannot supply parameter lists to unnamed (anonymous) queries"];
-err_msg({selection_on_enum_type, Ty}) ->
+err_uncategorized({selection_on_enum_type, Ty}) ->
     ["Cannot apply a selection set on the enum type ", format_ty(Ty)];
-err_msg(missing_non_null_param) ->
+err_uncategorized(missing_non_null_param) ->
     ["The parameter is non-null, but was undefined in parameter list"];
-err_msg({unbound_variable, Var}) ->
+err_uncategorized({unbound_variable, Var}) ->
     ["The document refers to a variable ", Var, " but no such var exists. Perhaps the variable is a typo?"];
-err_msg({input_coerce_abort, {Class, Reason}}) ->
+err_uncategorized({input_coerce_abort, {Class, Reason}}) ->
     io_lib:format("Input coercer failed with an exception of class ~p and reason ~p", [Class, Reason]);
-err_msg({input_coercion, Type, Value, Reason}) ->
+err_uncategorized({input_coercion, Type, Value, Reason}) ->
     io_lib:format("Input coercion failed for type ~s with value ~p. The reason it failed is: ~p", [Type, Value, Reason]);
-err_msg({excess_fields_in_object, Fields}) ->
+err_uncategorized({excess_fields_in_object, Fields}) ->
     io_lib:format("The object contains unknown fields and values: ~p", [Fields]);
-err_msg(Otherwise) ->
+err_uncategorized(Otherwise) ->
     io_lib:format("General uncategorized error: ~p", [Otherwise]).
 
 -spec path([Input]) -> [binary()]

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -629,7 +629,7 @@ missing_fragment(Config) ->
     ok.
 
 quoted_input_error(Config) ->
-    {error, {_Line, graphql_parser, _}} =
+    {error, {parser_error, {_Line, graphql_parser, _}}} =
         run(Config, "quoted_input.graphql", <<"IMonster">>, #{}).
 
 invalid_type_resolution(Config) ->

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -618,10 +618,11 @@ missing_fragment(Config) ->
     ID = base64:encode(<<"monster:1">>),
 
     #{errors :=
-          #{key := {unknown_fragment,<<"GoblinFragment">>},
+          #{key := unknown_fragment,
             path := [<<"document">>,
                      <<"GoblinQuery">>,
-                     <<"monster">>]}} =
+                     <<"monster">>,
+                     <<"GoblinFragment">>]}} =
         run(Config,
             "missing_fragment.graphql",
             <<"GoblinQuery">>,

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -603,7 +603,7 @@ nested_field_merge(Config) ->
 unknown_variable(Config) ->
     ID = base64:encode(<<"monster:1">>),
 
-    #{errors :=
+    #{ errors :=
           #{key := {unbound_variable,<<"i">>},
             path := [<<"document">>,
                      <<"GoblinQuery">>,
@@ -617,12 +617,12 @@ unknown_variable(Config) ->
 missing_fragment(Config) ->
     ID = base64:encode(<<"monster:1">>),
 
-    #{errors :=
+    #{ errors :=
           #{key := unknown_fragment,
             path := [<<"document">>,
                      <<"GoblinQuery">>,
                      <<"monster">>,
-                     <<"GoblinFragment">>]}} =
+                     <<"GoblinFragment">>] }} =
         run(Config,
             "missing_fragment.graphql",
             <<"GoblinQuery">>,


### PR DESCRIPTION
This set of patches intend to streamline error paths in the code base. The idea is we can handle errors better by doing a proper job on them. Each module will become responsible for its own errors and factoring will make sure categorization is easier to follow.

It also paves the way for user-defined errors later on.