### PR TITLE
Add support for auxiliary data in responses

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -259,15 +259,15 @@ complete_value(Path, _Ctx, #scalar_type { id = ID, resolve_module = RM }, _Field
     end;
 complete_value(_Path, _Ctx, #enum_type { id = ID, resolve_module = RM}, _Fields, {ok, Value}) ->
     try RM:output(ID, Value) of
-	{ok, Result} -> complete_value_enum(_Path, ID, Result);
-	{error, Reason} ->
-	    err(_Path, {ID, Value, Reason})
+    {ok, Result} -> complete_value_enum(_Path, ID, Result);
+    {error, Reason} ->
+        err(_Path, {ID, Value, Reason})
     catch
-	Cl:Err ->
-	    error_logger:error_msg(
-	      "crash during value completion: ~p, stacktrace: ~p~n",
-	      [{Cl, Err, ID, Value}, erlang:get_stacktrace()]),
-	     err(_Path, {coerce_crash, ID, Value, {Cl, Err}})
+    Cl:Err ->
+        error_logger:error_msg(
+          "crash during value completion: ~p, stacktrace: ~p~n",
+          [{Cl, Err, ID, Value}, erlang:get_stacktrace()]),
+         err(_Path, {coerce_crash, ID, Value, {Cl, Err}})
     end;
 complete_value(Path, Ctx, #interface_type{ resolve_type = Resolver }, Fields, {ok, Value}) ->
     complete_value_abstract(Path, Ctx, Resolver, Fields, {ok, Value});
@@ -289,7 +289,7 @@ complete_value_abstract(Path, Ctx, Resolver, Fields, {ok, Value}) ->
         {error, Reason} ->
             err(Path, Reason)
     end.
-    
+
 resolve_abstract_type(Module, Value) when is_atom(Module) ->
     resolve_abstract_type(fun Module:execute/1, Value);
 resolve_abstract_type(Resolver, Value) when is_function(Resolver, 1) ->
@@ -308,14 +308,14 @@ resolve_abstract_type(Resolver, Value) when is_function(Resolver, 1) ->
     end.
 
 complete_value_enum(_path, _ID, Result) when is_binary(Result) ->   {ok, Result, []};
-complete_value_enum( Path,  ID, Value) -> err(Path, {ID, Value, not_enum_type}). 
+complete_value_enum( Path,  ID, Value) -> err(Path, {ID, Value, not_enum_type}).
 
 complete_value_scalar(_Path, _ID, Result) when is_binary(Result) -> {ok, Result, []};
 complete_value_scalar(_Path, _ID, Result) when is_number(Result) -> {ok, Result, []};
 complete_value_scalar(_Path, _ID, true) -> {ok, true, []};
 complete_value_scalar(_Path, _ID, false) -> {ok, false, []};
 complete_value_scalar(_Path, _ID, null) -> {ok, null, []};
-complete_value_scalar( Path,  ID, Value) -> 
+complete_value_scalar( Path,  ID, Value) ->
     err(Path, {output_coerce, ID, Value, not_scalar_type}).
 
 assert_list_completion_structure(Ty, Fields, Results) ->
@@ -611,7 +611,7 @@ binarize(L) when is_list(L) -> list_to_binary(L).
 %% -- ERROR HANDLING --
 
 resolver_error_wrap([]) -> [];
-resolver_error_wrap([#{ reason := Reason } = E | Next]) -> 
+resolver_error_wrap([#{ reason := Reason } = E | Next]) ->
     [E#{ reason => {resolver_error, Reason} } | resolver_error_wrap(Next)].
 
 err(Path, Reason) ->
@@ -642,6 +642,3 @@ err_msg(list_resolution) ->
     ["Internal Server error: A list is being incorrectly resolved"];
 err_msg(Otherwise) ->
     io_lib:format("Error in execution: ~p", [Otherwise]).
-
-
-

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -31,16 +31,33 @@ execute_request(InitialCtx, {document, Operations}) ->
             complete_top_level(undefined, Errs)
     end.
 
-complete_top_level(Res, []) ->
-    #{ data => Res };
-complete_top_level(undefined, Errs) ->
+
+complete_top_level(undefined, Errs) when is_list(Errs) ->
     #{ errors => [complete_error(E) || E <- Errs ] };
+complete_top_level(Res, []) ->
+    Aux = collect_auxiliary_data(),
+    Result = #{ data => Res },
+    decorate_top_level(Result, aux, Aux);
 complete_top_level(Res, Errs) ->
-    #{ data => Res,
-       errors => [complete_error(E) || E <- Errs ] }.
+    Errors = [complete_error(E) || E <- Errs ],
+    Aux = collect_auxiliary_data(),
+    Result = #{ data => Res, errors => Errors },
+    decorate_top_level(Result, aux, Aux).
 
 complete_error(#{ path := Path, reason := Reason }) ->
     graphql_err:mk(Path, execute, Reason).
+
+decorate_top_level(Map, _, []) -> Map; % noop
+decorate_top_level(Map, aux, AuxiliaryDataList) ->
+    Map#{aux => AuxiliaryDataList}.
+
+collect_auxiliary_data() ->
+    receive
+        {'$auxiliary_data', AuxiliaryDataList} ->
+            AuxiliaryDataList ++ collect_auxiliary_data()
+    after 0 ->
+        []
+    end.
 
 execute_query(Ctx, #op { selection_set = SSet,
                           schema = QType } = Op) ->
@@ -187,6 +204,9 @@ resolve_field_value(Ctx, #object_type { id = OID, annotations = OAns} = ObjectTy
     end) of
         {error, Reason} -> {error, {resolver_error, Reason}};
         {ok, Result} -> {ok, Result};
+        {ok, Result, AuxiliaryDataList} when is_list(AuxiliaryDataList) ->
+            self() ! {'$auxiliary_data', AuxiliaryDataList},
+            {ok, Result};
         default ->
             resolve_field_value(Ctx, ObjectType, Value, Name, FAns, fun ?MODULE:default_resolver/3, Args);
         Wrong ->

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -527,7 +527,7 @@ value(#{ params := Params } = _Ctx, _Ty, {var, ID}) ->
     %% Parameter expansion and type check is already completed
     %% at this stage
     maps:get(name(ID), Params);
-value(Ctx, _Ty, null) ->
+value(_Ctx, _Ty, null) ->
     null;
 value(Ctx, {non_null, Ty}, Val) ->
     value(Ctx, Ty, Val);

--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -78,7 +78,7 @@ x_params(FunEnv, OpName, Params) ->
         TyVarEnv ->
             tc_params([OpName], TyVarEnv, Params)
     end.
-            
+
 tc_params(Path, TyVarEnv, InitialParams) ->
     F =
       fun(K, V0, PS) ->
@@ -200,7 +200,7 @@ input_coercer(Path, #scalar_type { id = ID, resolve_module = RM}, Val) ->
             err(Path, {input_coerce_abort, {Cl, Err}})
 
     end;
-input_coercer(Path, #enum_type { id = ID, resolve_module = undefined }, Val) ->
+input_coercer(_Path, #enum_type { resolve_module = undefined }, Val) ->
     {ok, Val};
 input_coercer(Path, #enum_type { id = ID, resolve_module = RM}, Val) ->
     try RM:input(ID, Val) of
@@ -254,7 +254,7 @@ tc_field(#{ fragenv := FE } = Ctx, Path, #frag_spread { id = ID, directives = Ds
             FSpread#frag_spread { directives = tc_directives(Ctx, Path, Ds) }
     end;
 tc_field(Ctx, Path, #frag { id = '...', selection_set = SSet, directives = Ds} = InlineFrag) ->
-    
+
     InlineFrag#frag {
         directives = tc_directives(Ctx, [InlineFrag | Path], Ds),
         selection_set = tc_sset(Ctx, [InlineFrag | Path], SSet)
@@ -388,7 +388,7 @@ value_type(_Ctx, _Path, _, F) when is_float(F) -> {scalar, float, F};
 value_type(_Ctx, _Path, _, true) -> {scalar, bool, true};
 value_type(_Ctx, _Path, _, false) -> {scalar, bool, false};
 value_type(_Ctx, _Path, _, Obj) when is_map(Obj) -> coerce_object(Obj);
-value_type(_Ctx, Path, Ty, Val) -> 
+value_type(_Ctx, Path, Ty, Val) ->
     err(Path, {invalid_value_type_coercion, Ty, Val}).
 
 refl_list(_Path, [], _T, Result) ->
@@ -504,4 +504,3 @@ err_msg({invalid_value_type_coercion, Ty, Val}) ->
     io_lib:format(
       "The value ~p cannot be coerced into the type ~p",
       [Val, Ty]).
-

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -185,7 +185,7 @@ include_directive(Config) ->
     end,
     #{ data := #{
          <<"goblin">> := #{
-             <<"id">> := GoblinID,
+             <<"id">> := GoblinId,
              <<"name">> := <<"goblin">>,
              <<"hitpoints">> := 10 }}} =
         run(Config, <<"GoblinQueryDirectives">>, #{ <<"fat">> => true }),
@@ -200,7 +200,7 @@ include_directive(Config) ->
     end,
     #{ data := #{
          <<"goblin">> := #{
-             <<"id">> := GoblinID,
+             <<"id">> := GoblinId,
              <<"name">> := <<"goblin">>,
              <<"hitpoints">> := 10 }}} =
         run(Config, <<"GoblinQueryDirectivesInline">>, #{ <<"fat">> => true }),
@@ -209,7 +209,7 @@ include_directive(Config) ->
 unions(Config) ->
     ct:log("Initial query on the schema"),
     Monster = dungeon:create(monster, [{name, <<"goblin">>}, {hitpoints, 10}]),
-    [{GoblinId, Goblin}] = dungeon:batch_create([{Monster, insert}]),
+    [{GoblinId, _Goblin}] = dungeon:batch_create([{Monster, insert}]),
     OpaqueId = dungeon:opaque_id(GoblinId),
     Expected1 = #{ data => #{
                      <<"goblin">> => #{
@@ -229,7 +229,7 @@ unions(Config) ->
 union_errors(Config) ->
     ct:log("You may not request fields on unions"),
     Monster = dungeon:create(monster),
-    [{GoblinId, Goblin}] = dungeon:batch_create([{Monster, insert}]),
+    [{GoblinId, _Goblin}] = dungeon:batch_create([{Monster, insert}]),
     OpaqueId = dungeon:opaque_id(GoblinId),
     Query = iolist_to_binary(["{ goblin: thing(id: \"", OpaqueId ,"\") { id } }"]),
     Q1 = binary_to_list(Query),
@@ -243,7 +243,7 @@ scalar_output_coercion(Config) ->
                                 , {color, #{ r => 65, g => 146, b => 75}}
                                 , {hitpoints, 10}
                                 ]),
-    [{GoblinId, Goblin}] = dungeon:batch_create([{Monster, insert}]),
+    [{GoblinId, _Goblin}] = dungeon:batch_create([{Monster, insert}]),
     OpaqueId = dungeon:opaque_id(GoblinId),
     #{ data := #{
         <<"goblin">> := #{
@@ -257,7 +257,7 @@ scalar_output_coercion(Config) ->
 replace_enum_representation(Config) ->
     ct:log("Test replace enum representation"),
     Monster = dungeon:create(monster, [{mood, "dodgy"}]),
-    [{GoblinId, Goblin}] = dungeon:batch_create([{Monster, insert}]),
+    [{GoblinId, _Goblin}] = dungeon:batch_create([{Monster, insert}]),
     OpaqueId = dungeon:opaque_id(GoblinId),
     #{ data := #{
          <<"goblin">> := #{
@@ -603,11 +603,10 @@ multiple_monsters_and_rooms(Config) ->
 
     Room1 = ?config(known_room_id, Config),
     NonExistentRoom = ?config(known_non_existent_room_id, Config),
-
     #{ data := #{
          <<"rooms">> := [#{<<"id">> := Room1}]}
      } = run(Config, <<"MultipleRooms">>, #{ <<"ids">> => [Room1]}),
-
+    % look for an existing room and a non existing room
     #{ data := #{ <<"rooms">> := null },
        errors :=
            [#{path := [<<"MultipleRooms">>, <<"rooms">>, 1],
@@ -615,7 +614,7 @@ multiple_monsters_and_rooms(Config) ->
             #{path := [<<"MultipleRooms">>, <<"rooms">>, 1],
               key := not_found } ]
      } = run(Config, <<"MultipleRooms">>,
-             #{ <<"ids">> => [Room1, base64:encode(<<"room:2">>)]}),
+             #{ <<"ids">> => [Room1, NonExistentRoom]}),
     ok.
 
 inline_fragment(Config) ->
@@ -659,7 +658,8 @@ nested_field_merge(Config) ->
               <<"attack">> := 3,
               <<"shellScripting">> := 3,
               <<"yell">> := <<"HELO">> }]
-    }}} = Res = run(Config, <<"TestNestedFieldMerge">>, #{ <<"id">> => ID }),
+    }}} = run(Config, <<"TestNestedFieldMerge">>, #{ <<"id">> => ID }),
+    ok.
     ok.
 
 unknown_variable(Config) ->

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -77,6 +77,7 @@ groups() ->
          , get_operation
          , coercion_int_float
          , replace_enum_representation
+         , auxiliary_data
          ]},
     Errors =
         {errors, [],
@@ -660,7 +661,18 @@ nested_field_merge(Config) ->
               <<"yell">> := <<"HELO">> }]
     }}} = run(Config, <<"TestNestedFieldMerge">>, #{ <<"id">> => ID }),
     ok.
-    ok.
+
+auxiliary_data(Config) ->
+    Monster = dungeon:create(monster, [{name, <<"Auxiliary Undead">>}]),
+    [{GoblinId, _Goblin}] = dungeon:batch_create([{Monster, insert}]),
+    {ok, OpaqueId} = dungeon:wrap(GoblinId),
+    Expected = #{
+      aux => [{my_auxiliary_data, true}],
+      data => #{ <<"monster">> => #{ <<"id">> => OpaqueId
+                                   , <<"name">> => <<"Auxiliary Undead">>}
+               }
+     },
+    Expected = run(Config, <<"TestAuxiliaryData">>, #{<<"id">> => OpaqueId}).
 
 unknown_variable(Config) ->
     ID = ?config(known_goblin_id_1, Config),

--- a/test/dungeon_SUITE_data/dungeon.graphql
+++ b/test/dungeon_SUITE_data/dungeon.graphql
@@ -69,7 +69,7 @@ query MultipleMonstersExpr {
 }
 
 query MultipleMonstersExprMissing {
-    monsters(ids: ["bW9uc3Rlcjox", "bW9uc3RlcjoxMDAw", "bW9uc3Rlcjoy", "bW9uc3RlcjoxMDAx"]) {
+    monsters(ids: ["bW9uc3Rlcjox", "bW9uc3Rlcjoz", "bW9uc3Rlcjoy", "bW9uc3Rlcjo0"]) {
         id
     }
 }
@@ -239,7 +239,7 @@ mutation IntroduceMonsterFatFixedInput {
 mutation IntroduceMonsterFatExpr {
   introduceMonster(input:
     { clientMutationId: "123",
-      name: "Green Slime", 
+      name: "Green Slime",
       color: "#1be215",
       hitpoints: 9001,
       mood: TRANQUIL,

--- a/test/dungeon_SUITE_data/dungeon.graphql
+++ b/test/dungeon_SUITE_data/dungeon.graphql
@@ -189,6 +189,13 @@ fragment MonsterFragmentNested2 on Monster {
     stats { shellScripting }
 }
 
+query TestAuxiliaryData($id: Id!) {
+  monster(id: $id) {
+    id
+    name
+  }
+}
+
 ## MUTATIONS
 mutation IntroduceMonster($input: IntroduceMonsterInput!) {
   introduceMonster(input: $input) {

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -3,6 +3,11 @@
 
 -export([execute/4]).
 
+% this path is used for testing auxiliary data
+execute(_Ctx, #monster {id = ID, name = <<"Auxiliary Undead">>}, <<"id">>, _Args) ->
+    {ok, WrappedId} = dungeon:wrap({monster, ID}),
+    {ok, WrappedId, [{my_auxiliary_data, true}]};
+% default
 execute(_Ctx, #monster { id = ID,
                          name = Name,
                          hitpoints = HP,
@@ -54,4 +59,3 @@ stats(null, _) ->
 stats(SS, #{ <<"minAttack">> := Min }) ->
     {ok, [{ok, S} || S <- SS,
                      S#stats.attack >= Min]}.
-

--- a/test/dungeon_query.erl
+++ b/test/dungeon_query.erl
@@ -28,4 +28,3 @@ execute(_Ctx, _, <<"rooms">>, #{ <<"ids">> := InputIDs }) ->
               {room, _} = OID = dungeon:unwrap(ID),
               dungeon:dirty_load(OID)
           end || ID <- InputIDs]}.
-

--- a/test/dungeon_query.erl
+++ b/test/dungeon_query.erl
@@ -17,7 +17,7 @@ execute(_Ctx, _, <<"thing">>, #{ <<"id">> := InputID }) ->
     case dungeon:unwrap(InputID) of
         {monster, _ID} = OID -> dungeon:dirty_load(OID);
         {item, _ID} = OID -> dungeon:dirty_load(OID);
-        {kraken, _ID} = OID -> {ok, kraken}
+        {kraken, _ID} = _OID -> {ok, kraken}
     end;
 execute(_Ctx, _, <<"room">>, #{ <<"id">> := InputID }) ->
     case dungeon:unwrap(InputID) of

--- a/test/dungeon_room.erl
+++ b/test/dungeon_room.erl
@@ -5,7 +5,7 @@
 
 execute(_Ctx, #room { id = ID,
                       description = Desc,
-                      contents = Contents }, F, A) ->
+                      contents = Contents }, F, _A) ->
     case F of
         <<"id">> -> dungeon:wrap({room, ID});
         <<"description">> -> {ok, Desc};

--- a/test/dungeon_type.erl
+++ b/test/dungeon_type.erl
@@ -5,7 +5,7 @@
 
 execute(#monster{}) -> {ok, 'Monster'};
 execute(kraken) -> {error, kraken};
-execute(X) -> 
+execute(X) ->
     case dungeon:unwrap(X) of
         {Ty, _} -> object_type(Ty)
     end.

--- a/test/graphql_SUITE.erl
+++ b/test/graphql_SUITE.erl
@@ -79,7 +79,7 @@ groups() ->
         star_wars_query_aliases,
         star_wars_fragments,
         star_wars_typename,
-        
+
         %% Validation tests
         star_wars_complex,
         star_wars_non_existent_field,
@@ -89,7 +89,7 @@ groups() ->
         star_wars_object_field_in_inline_fragments,
         star_wars_object_field_in_fragments
     ]},
-    
+
     EnumType = {enum_type, [shuffle, parallel], [
         enum_input,
         enum_output,
@@ -115,20 +115,21 @@ groups() ->
        is_supports_type
     ]},
 
-    Validation = {validation, [parallel], [
-    	v_5_1_1_1,
-    	v_5_1_2_1,
-    	v_5_2_1,
-    	v_5_2_3,
-    	v_5_3_1,
-    	v_5_3_2,
-    	v_5_4_1_1,
-    	v_5_4_1_2,
-    	v_5_4_1_3,
-	v_5_4_2_1,
-	v_5_4_2_2,
-	v_5_4_2_3_1
-    ]},
+    Validation =
+        {validation, [parallel],
+         [ v_5_1_1_1
+         , v_5_1_2_1
+         , v_5_2_1
+         , v_5_2_3
+         , v_5_3_1
+         , v_5_3_2
+         , v_5_4_1_1
+         , v_5_4_1_2
+         , v_5_4_1_3
+         , v_5_4_2_1
+         , v_5_4_2_2
+         , v_5_4_2_3_1
+         ]},
 
     [Basic, SW, EnumType, Schema, SchemaTest, Validation, Introspection].
 
@@ -173,7 +174,7 @@ parse_schema(Config) ->
                                 interfaces => #{
                                  'Node' => node_resource
                                  },
-				enums => #{default => enum_resource}, 
+                enums => #{default => enum_resource},
                                 unions => #{
                                  'Thing' => node_resource
                                  },
@@ -198,7 +199,7 @@ star_wars_hero(Config) ->
         "}",
     #{ data :=
         #{ <<"hero">> := #{ <<"name">> := <<"R2-D2">> } } } = th:x(Config, Q1),
-    
+
     Q2 =
        "query HeroNameQuery {"
        "  hero(episode: EMPIRE) {"
@@ -208,7 +209,7 @@ star_wars_hero(Config) ->
     #{ data :=
         #{ <<"hero">> := #{ <<"name">> := <<"Luke Skywalker">> } } } = th:x(Config, Q2),
     ok.
-    
+
 star_wars_friends(Config) ->
     Q1 =
       "query HeroNameAndFriendsQuery {"
@@ -226,8 +227,8 @@ star_wars_friends(Config) ->
                 #{ <<"name">> := <<"Luke Skywalker">> },
                 #{ <<"name">> := <<"Han Solo">> },
                 #{ <<"name">> := <<"Leia Organa">> } ] } } } = th:x(Config, Q1),
-                
-    Q2 = 
+
+    Q2 =
       "query NestedQuery {"
       "  hero {"
       "      name"
@@ -325,11 +326,11 @@ star_wars_fragments(Config) ->
       "   leia: human(id: \"1003\") { name homePlanet } }",
     Expected = #{ data => #{
           <<"luke">> => #{
-          	<<"name">> => <<"Luke Skywalker">>,
-          	<<"homePlanet">> => <<"Tatooine">> },
+            <<"name">> => <<"Luke Skywalker">>,
+            <<"homePlanet">> => <<"Tatooine">> },
           <<"leia">> => #{
-          	<<"name">> => <<"Leia Organa">>,
-          	<<"homePlanet">> => <<"Alderaan">> } } },
+            <<"name">> => <<"Leia Organa">>,
+            <<"homePlanet">> => <<"Alderaan">> } } },
     Expected = th:x(Config, Q1),
     Q2 =
       "query UseFragment {"
@@ -341,7 +342,7 @@ star_wars_fragments(Config) ->
       "    homePlanet"
       "}",
     Expected = th:x(Config, Q2),
-    
+
     ok.
 
 star_wars_typename(Config) ->
@@ -355,7 +356,7 @@ star_wars_typename(Config) ->
     }},
     Expected = th:x(Config, Q1),
     ok.
-    
+
 %% -- STAR WARS™ VALIDATION ------------------------------
 
 star_wars_complex(Config) ->
@@ -460,7 +461,7 @@ enum_no_literal_int(Config) ->
     Q1 = "{ colorEnum(fromInt: GREEN) }",
     th:errors(th:x(Config, Q1)),
     ok.
-    
+
 enum_accept_json(Config) ->
     Q1 = "query test($color: Color!) { colorEnum(fromEnum: $color) }",
     #{ data :=
@@ -479,7 +480,7 @@ enum_no_accept_internal_query(Config) ->
     Q1 = "query test($color: Color!) { colorEnum(fromEnum: $color) }",
     th:errors(th:x(Config, Q1, <<"test">>, #{ <<"color">> => 2 })),
     ok.
-    
+
 enum_no_accept_internal_query_2(Config) ->
     Q1 = "query test($color: String!) { colorEnum(fromEnum: $color) }",
     th:errors(th:x(Config, Q1, <<"test">>, #{ <<"color">> => <<"BLUE">> })),
@@ -500,14 +501,14 @@ enum_internal_zero(Config) ->
 enum_input_nullable(Config) ->
     Q1 = "{ colorEnum colorInt }",
     #{ data := #{
-    	<<"colorEnum">> := null,
-    	<<"colorInt">> := null
+        <<"colorEnum">> := null,
+        <<"colorInt">> := null
     }} = th:x(Config, Q1),
     ok.
 
 %% -- SCHEMA TEST --------------------------------
 schema_test(Config) ->
-    Q = 
+    Q =
       "{ feed { id, title }, "
       "  article(id: 1) { ...articleFields, author { id, name, pic(width: 640, height: 480) {"
       "     url, width, height }, recentArticle { ...articleFields, keywords }}}} "
@@ -557,12 +558,12 @@ v_5_1_1_1(_Config) ->
       "query getDogName { dog { name } } "
       "query getOwnerName { dog { owner { name } } }",
     true = th:v(Q1),
-    
+
     Q2 =
       "query getName { dog { name } } "
       "query getName { dog { owner { name } } }",
     false = th:v(Q2),
-    
+
     Q3 =
       "query dogOperation { dog { name } } "
       "mutation dogOperation { mutateDog { id } } ",
@@ -581,27 +582,27 @@ v_5_2_1(_Config) ->
       "{ dog { ...fieldNotDefined } } "
       "fragment fieldNotDefined on Dog { meowVolume }",
     false = th:v(Q1),
-    
+
     Q2 =
       "{ dog { ...lyingFragment } } "
       "fragment lyingFragment on Dog { barkVolume: kawVolume }",
     false = th:v(Q2),
-    
+
     Q3 =
       "{ dog { ...PetFragment } } "
       "fragment PetFragment on Pet { name }",
     true = th:v(Q3),
-    
+
     Q4 =
       "{ dog { ...PetFragment } } "
       "fragment PetFragment on Pet { nickname }",
     false = th:v(Q4),
-    
+
     Q5 =
       "{ dog { ...Fragment } } "
       "fragment Fragment on CatOrDog { __typename ... on Pet { name } ... on Dog { barkVolume } }",
     true = th:v(Q5),
-    
+
     Q6 =
       "{ dog { ...Fragment } } "
       "fragment Fragment on CatOrDog { name barkVolume }",
@@ -612,11 +613,11 @@ v_5_2_3(_Config) ->
     Q1 =
        "{ dog { ...scalarSelection } } fragment scalarSelection on Dog { barkVolume }",
     true = th:v(Q1),
-    
+
     Q2 =
        "{ dog { ...Fragment }} fragment Fragment on Dog { barkVolume { sinceWhen }}",
     false = th:v(Q2),
-    
+
     false = th:v("query Q { human } }"),
     false = th:v("query Q { pet } }"),
     false = th:v("query Q { catOrDog } }"),
@@ -625,13 +626,13 @@ v_5_2_3(_Config) ->
 v_5_3_1(_Config) ->
     true = th:v(
       "{ dog { ...F } } fragment F on Dog { doesKnowCommand(dogCommand: SIT) }"),
-      
+
     false = th:v(
       "{ dog { ...F } } fragment F on Dog { doesKnowCommand(command: CLEAN_UP_HOUSE) }"),
-    
+
     true = th:v(
       "{ dog { ...F } } fragment F on Arguments { multipleReqs(x: 1, y: 2) }"),
-    
+
     true = th:v(
       "{ dog { ...F } } fragment F on Arguments { multipleReqs(y:1, x: 2) }"),
 
@@ -640,7 +641,7 @@ v_5_3_1(_Config) ->
 v_5_3_2(_Config) ->
     true = th:v(
       "{ dog { ...F } } fragment F on Dog { doesKnowCommand(dogCommand: SIT) }"),
-      
+
     false = th:v(
       "{ dog { ...F } } fragment F on Dog { doesKnowCommand(dogCommand: SIT, dogCommand: HEEL) }"),
     ok.
@@ -651,7 +652,7 @@ v_5_4_1_1(_Config) ->
         "fragment fragOne on Dog { name } "
         "fragment fragTwo on Dog { owner { name } }",
     true = th:v(Q1),
-    
+
     Q2 =
         "{ dog { ...fragOne } } "
         "fragment fragOne on Dog { name } "
@@ -663,21 +664,21 @@ v_5_4_1_2(_Config) ->
     Q1 =
         "{ dog { ...correctType } } fragment correctType on Dog { name }",
     true = th:v(Q1),
-    
+
     Q2 =
         "{ dog { ...inlineFragment } } fragment inlineFragment on Dog { ... on Dog { name } }",
     true = th:v(Q2),
-    
+
     %% Note: This doesn't validate if we have no directives support. The test case will fail once
     %% we have it in which case the test here should pass.
     Q3 =
         "{ dog { ...inlineFragment2 } } fragment inlineFragment2 on Dog { ... @include(if: true) { name } }",
     false = th:v(Q3),
-    
+
     Q4 =
         "{ dog { ...F } } fragment F on NotInSchema { name }",
     false = th:v(Q4),
-    
+
     Q5 =
         "{ dog { ...F } } fragment F on Dog { ... on NotInSchema { name } }",
     false = th:v(Q5),
@@ -690,7 +691,7 @@ v_5_4_1_3(_Config) ->
       "{ dog { ...F } } fragment F on Pet { name }"),
     true = th:v(
       "{ dog { ...F } } fragment F on CatOrDog { ... on Dog { name } }"),
-      
+
     false = th:v(
       "{ dog { ...F } } fragment F on Int { something }"),
     false = th:v(
@@ -709,7 +710,7 @@ v_5_4_2_2(_Config) ->
       "fragment nameFragment on Dog { name ...barkVolumeFragment } "
       "fragment barkVolumeFragment on Dog { barkVolume ...nameFragment }",
     false = th:v(Q1),
-    
+
     Q2 =
       "{ dog { ...dogFragment } } "
       "fragment dogFragment on Dog { name owner { ...ownerFragment } } "
@@ -720,26 +721,25 @@ v_5_4_2_2(_Config) ->
 v_5_4_2_3_1(_Config) ->
    true = th:v(
      "{ dog { ...F } } fragment F on Dog { ... on Dog { barkVolume } }"),
-   
+
    false = th:v(
      "{ dog { ...F } } fragment F on Dog { ... on Cat { meowVolume } }"),
-     
+
    ok.
 
 %% -- INTERNALS ----------------------------------
 
 is_schema() ->
     Test = {object, #{
-    	id => 'TestType',
-    	description => "A simple test object.",
-    	fields => #{
-    		testField => #{ type => string, description => "A test field" }
-    	}
+        id => 'TestType',
+        description => "A simple test object.",
+        fields => #{
+            testField => #{ type => string, description => "A test field" }
+        }
     }},
     Schema = {root, #{
-    	query => 'TestType'
+        query => 'TestType'
     }},
     ok = graphql:insert_schema_definition(Test),
     ok = graphql:insert_schema_definition(Schema),
     ok.
-

--- a/test/graphql_SUITE.erl
+++ b/test/graphql_SUITE.erl
@@ -160,7 +160,7 @@ lex_schema(Config) ->
     FName = filename:join([?config(data_dir, Config), "test_schema.spec"]),
     {ok, Data} = file:read_file(FName),
     case graphql_scanner:string(binary_to_list(Data)) of
-        {ok, Token, _EndLine} ->
+        {ok, _Token, _EndLine} ->
             ok;
         {error, Err, _EndLine} ->
             ct:fail({parse_error, Err})


### PR DESCRIPTION
In some cases it is convenient to pass auxiliary data with the result; data that should not go directly to the end-user but should trigger some side-effect in the transport before sending data/error to the response body. This has been solved by using message passing and collect these just before we complete the top-level.

In resolvers one can, besides the two-ok-tuple (which has the old behaviour), return a three-ok-tuple which behave like this:

```
{ok, any(), [term()]}
```

The response map will now contain an `aux`-field which contain a list of terms, which can be used to modify the response object, such as a Cowboy response object, and set a cookie, add a header, etc.

N.B.: Errors cannot set auxiliary data, and one should not rely on the order in the auxiliary data list.

In this pull request I also made it a bit easier to add new tests to the Dungeon common test suite.