### PR TITLE
Merge Enum and Scalar coercion into one.

### DIFF
--- a/src/graphql_enum_coerce.erl
+++ b/src/graphql_enum_coerce.erl
@@ -1,16 +1,9 @@
 -module(graphql_enum_coerce).
 
--export([input/2,
-	 output/2]).
+-export([input/2, output/2]).
 
 input(_, X) ->
     {ok, X}.
 
 output(_, Y) ->
     {ok, Y}.
-
-
-
-    
-
-

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -206,7 +206,7 @@ complete_value(Path, Ctx, Ty, Fields, {ok, {enum, Value}}) ->
     complete_value(Path, Ctx, Ty, Fields, {ok, Value});
 
 complete_value(Path, Ctx, {scalar, Scalar}, Fields, {ok, Value}) ->
-    complete_value(Path, Ctx, output_coerce_type(Scalar), Fields, {ok, Value});
+    complete_value(Path, Ctx, scalar_resolve(Scalar), Fields, {ok, Value});
 
 complete_value(Path, Ctx, Ty, Fields, {ok, Value}) when is_binary(Ty) ->
     error_logger:warning_msg(
@@ -424,38 +424,33 @@ default_resolver(#{ field := Field}, Cur, _Args) ->
 
 %% -- OUTPUT COERCION ------------------------------------
 
-output_coerce_type(id) ->
+scalar_resolve(id) ->
     #scalar_type { id = <<"ID">>,
-                   input_coerce = fun ?MODULE:builtin_input_coercer/1,
                    description = <<"Builtin output coercer type">>,
                    resolve_module = graphql_scalar_binary_coerce
                    };
-output_coerce_type(string) ->
+scalar_resolve(string) ->
     #scalar_type { id = <<"String">>,
-                   input_coerce = fun ?MODULE:builtin_input_coercer/1,
                    description = <<"Builtin output coercer type">>,
                    resolve_module = graphql_scalar_binary_coerce
                  };
-output_coerce_type(bool) ->
+scalar_resolve(bool) ->
     #scalar_type { id = <<"Bool">>,
-                   input_coerce = fun ?MODULE:builtin_input_coercer/1,
                    description = <<"Builtin output coercer type">>,
                    resolve_module = graphql_scalar_bool_coerce
                  };
-output_coerce_type(int) ->
+scalar_resolve(int) ->
     #scalar_type { id = <<"Int">>,
-                   input_coerce = fun ?MODULE:builtin_input_coercer/1,
                    description = <<"Builtin output coercer type">>,
                    resolve_module = graphql_scalar_integer_coerce
                  };
-output_coerce_type(float) ->
+scalar_resolve(float) ->
     #scalar_type { id = <<"Float">>,
-                   input_coerce = fun ?MODULE:builtin_input_coercer/1,
                    description = <<"Builtin output coercer type">>,
                    resolve_module = graphql_scalar_float_coerce
                  };
-output_coerce_type(#scalar_type{} = SType) -> SType;
-output_coerce_type(UserDefined) when is_binary(UserDefined) ->
+scalar_resolve(#scalar_type{} = SType) -> SType;
+scalar_resolve(UserDefined) when is_binary(UserDefined) ->
     case graphql_schema:lookup(UserDefined) of
         #scalar_type{} = SType -> SType;
         not_found -> not_found

--- a/src/graphql_scalar_binary_coerce.erl
+++ b/src/graphql_scalar_binary_coerce.erl
@@ -1,0 +1,12 @@
+-module(graphql_scalar_binary_coerce).
+
+-export([input/2, output/2]).
+
+input(_, X) ->
+    {ok, X}.
+
+output(_,B) when is_binary(B) ->
+    {ok, B};
+
+output(_,_) ->
+    {ok, null}.

--- a/src/graphql_scalar_bool_coerce.erl
+++ b/src/graphql_scalar_bool_coerce.erl
@@ -1,0 +1,21 @@
+-module(graphql_scalar_bool_coerce).
+
+-export([input/2, output/2]).
+
+input(_, X) ->
+    {ok, X}.
+
+output(<<"Bool">>, true) ->
+    {ok, true};
+
+output(<<"Bool">>, <<"true">>) ->
+    {ok, true};
+
+output(<<"Bool">>, false) ->
+    {ok, false};
+
+output(<<"Bool">>, <<"false">>) ->
+    {ok, false};
+
+output(_,_) ->
+    {ok, null}.

--- a/src/graphql_scalar_float_coerce.erl
+++ b/src/graphql_scalar_float_coerce.erl
@@ -1,0 +1,15 @@
+-module(graphql_scalar_float_coerce).
+
+-export([input/2, output/2]).
+
+input(_, X) ->
+    {ok, X}.
+
+output(<<"Float">>, F) when is_float(F) ->
+    {ok, F};
+
+output(<<"Float">>,I) when is_integer(I) ->
+    {ok, float(I)};
+
+output(_,_) ->
+  {ok, null}.

--- a/src/graphql_scalar_integer_coerce.erl
+++ b/src/graphql_scalar_integer_coerce.erl
@@ -1,0 +1,12 @@
+-module(graphql_scalar_integer_coerce).
+
+-export([input/2, output/2]).
+
+input(_, X) ->
+    {ok, X}.
+
+output(<<"Int">>, I) when is_integer(I) ->
+    {ok, I};
+
+output(_,_) ->
+  {ok, null}.

--- a/src/graphql_schema.hrl
+++ b/src/graphql_schema.hrl
@@ -24,7 +24,7 @@
 -record(enum_type,
         { id :: binary(),
           description :: binary(),
-	  resolve_module = undefined :: mod(),
+          resolve_module = graphql_enum_coerce :: mod(),
           annotations = #{} :: #{ binary() => any() },
           values :: #{ integer() => enum_value() }
         }).
@@ -75,8 +75,8 @@
         { id :: binary(),
           description :: binary(),
           annotations = #{} :: #{ binary() => any() },
-          resolve_module = undefined :: mod(),
-          output_coerce :: fun ((any()) -> {ok, any()} | {error, any()}),
+          resolve_module = graphql_enum_coerce :: mod(),
+          output_coerce :: undefined | fun ((any()) -> {ok, any()} | {error, any()}),
           input_coerce  :: fun((any()) -> {ok, any()} | {error, any()})
         }).
 -type scalar_type() :: #scalar_type{}.

--- a/src/graphql_schema.hrl
+++ b/src/graphql_schema.hrl
@@ -75,9 +75,7 @@
         { id :: binary(),
           description :: binary(),
           annotations = #{} :: #{ binary() => any() },
-          resolve_module = graphql_enum_coerce :: mod(),
-          output_coerce :: undefined | fun ((any()) -> {ok, any()} | {error, any()}),
-          input_coerce  :: fun((any()) -> {ok, any()} | {error, any()})
+          resolve_module = graphql_enum_coerce :: mod()
         }).
 -type scalar_type() :: #scalar_type{}.
 

--- a/src/graphql_schema_canonicalize.erl
+++ b/src/graphql_schema_canonicalize.erl
@@ -27,13 +27,13 @@ x({union, #{ id := ID, description := Desc, types := Types } = U}) ->
     };
 
 x({enum, #{ id := ID, description := Desc, values := VDefs} = E}) ->
-    {Mod} = enum_resolve(E),
+    ModuleResolver = enum_resolve(E),
     #enum_type {
     	id = c_id(ID),
     	description = binarize(Desc),
     	annotations = annotations(E),
     	values = map_2(fun c_enum_val/2, VDefs),
-        resolve_module = Mod
+        resolve_module = ModuleResolver
      };
 
 x({object, #{ id := ID, fields := FieldDefs, description := Desc } = Obj}) ->
@@ -53,16 +53,22 @@ x({input_object, #{ id := ID, fields := FieldDefs, description := Desc } = IO}) 
          fields = map_2(fun c_input_value/2, FieldDefs) };
 
 %% Scalar--START
-x({scalar, #{ id := ID,
-              description := Desc} = Data}) ->
-    {Mod, InFun, OutFun} = scalar_resolve(Data),
+%% user defined scalars path
+x({scalar, #{ id := ID, description := Desc, resolve_module := ResolverModule} = Data}) ->
     #scalar_type {
        id = c_id(ID),
        description = binarize(Desc),
        annotations = annotations(Data),
-       resolve_module = Mod,
-       input_coerce = InFun,
-       output_coerce = OutFun }.
+       resolve_module = ResolverModule };
+
+%% graphql-erlang default scalars path
+x({scalar, #{ id := ID, description := Desc} = Data}) ->
+    ModuleResolver = scalar_resolve(ID),
+    #scalar_type {
+       id = c_id(ID),
+       description = binarize(Desc),
+       annotations = annotations(Data),
+       resolve_module = ModuleResolver }.
 
 %% -- ROOT -------------
 root_query(#{ query := Q}) -> binarize(Q);
@@ -92,7 +98,7 @@ c_enum_val(K, #{ value := V, description := Desc } = Map) ->
 
 c_input_value(K, V) ->
     {binarize(K), c_input_value_val(V)}.
-     
+
 c_input_value_val(#{ type := Ty, description := Desc } = M) ->
     Def = default(M),
     #schema_arg {
@@ -106,7 +112,7 @@ default(#{ }) -> null.
 
 c_field(K, V) ->
     {binarize(K), c_field_val(V)}.
-    
+
 c_field_val(M) ->
     #schema_field {
     	ty = c_field_val_ty(M),
@@ -135,7 +141,7 @@ handle_type({non_null, Ty}) -> {non_null, handle_type(Ty)};
 handle_type([Ty]) -> {list, handle_type(Ty)};
 handle_type({list, Ty}) -> {list, handle_type(Ty)};
 handle_type(A) when is_atom(A) -> non_null(atom_to_list(A)).
-    
+
 non_null(Ty) ->
     case lists:reverse(Ty) of
         [$! | Rest] -> {non_null, list_to_binary(lists:reverse(Rest))};
@@ -178,27 +184,28 @@ map_2(F, M) ->
     Unpacked = maps:to_list(M),
     maps:from_list([F(K, V) || {K, V} <- Unpacked]).
 
-scalar_resolve(#{ coerce_module := Mod }) when is_atom(Mod) ->
-    {Mod, undefined, undefined};
-scalar_resolve(#{ input_coerce := In, output_coerce := Out} )
-  when is_function(In, 1),
-       is_function(Out, 1) ->
-    {undefined, In, Out};
-scalar_resolve(#{ id := ID, input_coerce := _, output_coerce := _ }) ->
-    exit({scalar_coercers_wrong_fun_arity, ID});
-scalar_resolve(#{ id := ID, output_coerce := _ }) ->
-    exit({missing_input_coerce, ID});
-scalar_resolve(#{ id := ID, input_coerce := _ }) ->
-    exit({missing_output_coerce, ID});
-scalar_resolve(#{}) ->
-    {undefined,
-     fun(X) -> {ok, X} end,
-     fun(X) -> {ok, X} end}.
+scalar_resolve('ID') ->
+     graphql_scalar_binary_coerce;
 
-enum_resolve(#{ resolve_module := Mod }) when is_atom(Mod) ->
-    {Mod};
+scalar_resolve('String') ->
+     graphql_scalar_binary_coerce;
+
+scalar_resolve('Bool') ->
+     graphql_scalar_bool_coerce;
+
+scalar_resolve('Int') ->
+     graphql_scalar_integer_coerce;
+
+scalar_resolve('Float') ->
+     graphql_scalar_float_coerce;
+
+scalar_resolve(_) ->
+     graphql_enum_coerce.
+
+enum_resolve(#{ resolve_module := ModuleResolver }) when is_atom(ModuleResolver) ->
+    ModuleResolver;
 enum_resolve(_) ->
-    {graphql_enum_coerce}.
+    graphql_enum_coerce.
 
 %% -- Annotations
 annotations(#{ annotations := Annots }) -> Annots;

--- a/src/graphql_schema_parse.erl
+++ b/src/graphql_schema_parse.erl
@@ -19,7 +19,7 @@ mk(#{ scalars := Sc }, #p_scalar { id = ID, annotations = Annots }) ->
        id => Name,
        description => Description,
        annotations => annotations(Annots),
-       coerce_module => Mod
+       resolve_module => Mod
       }};
 mk(#{ unions := Us }, #p_union { id = ID,
                                  annotations = Annots,

--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -176,31 +176,17 @@ input_coerce_scalar(Path, #scalar_type {} = SType, Val) ->
 input_coerce_scalar(Path, Ty, _V) ->
     err(Path, {type_mismatch, #{ schema => {scalar, Ty}}}).
 
-input_coercer(Path, #scalar_type { id = ID, input_coerce = IC, resolve_module = undefined }, Val) ->
-    try IC(Val) of
-        {ok, NewVal} -> {replace, NewVal};
-        {error, Reason} -> err(Path, {input_coercion, ID, Val, Reason})
-    catch
-        Cl:Err ->
-            error_logger:error_report(
-              [
-               {input_coercer, ID, Val},
-               {error, Cl, Err},
-               {stack, erlang:get_stacktrace()}
-              ]),
-            err(Path, {input_coerce_abort, {Cl, Err}})
-    end;
 input_coercer(Path, #scalar_type { id = ID, resolve_module = RM}, Value) ->
     complete_value_scalar(Path, ID, RM, Value);
 
 input_coercer(_Path, #enum_type { id = _ID, resolve_module = undefined }, Value) ->
     {ok, Value};
 
-input_coercer(Path, #enum_type { id = ID, resolve_module = RM}, Value) ->
-    complete_value_scalar(Path, ID, RM, Value).
+input_coercer(Path, #enum_type { id = ID, resolve_module = ResolveModule}, Value) ->
+    complete_value_scalar(Path, ID, ResolveModule, Value).
 
-complete_value_scalar(Path, ID, RM, Value) ->
-    try RM:input(ID, Value) of
+complete_value_scalar(Path, ID, ResolveModule, Value) ->
+    try ResolveModule:input(ID, Value) of
         {ok, NewVal} ->
             {replace, NewVal};
 
@@ -212,7 +198,6 @@ complete_value_scalar(Path, ID, RM, Value) ->
             error_report(ID, Value, Cl, Err),
             err(Path, {input_coerce_abort, {Cl, Err}})
     end.
-
 
 error_report(ID, Val, Cl, Err) ->
   error_logger:error_report(


### PR DESCRIPTION
This PR is related with ![](https://github.trello.services/images/mini-trello-icon.png) [GraphQL: Merge Enum and Scalar coercion into one](https://trello.com/c/QFjQMTAD/805-graphql-merge-enum-and-scalar-coercion-into-one-rid-ourselves-of-builtin-scalarst) task
 Also I deleted the `input_coerce` & `output_coerce` fields and I replace that with `resolve_module` to work in the same way as the others default entities on the graph