### PR TITLE
Make the closure core compile

### DIFF
--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -48,6 +48,7 @@ token(#{ defer_process := Proc, defer_request_id := ReqId }) ->
 token_ref({'$graphql_token', _, _, Ref}) -> Ref.
 
 reply_cast({'$graphql_token', Target, Id, Ref}, Data) ->
+    error_logger:info_msg("Replying: ~p", [{Target, Id, Ref, Data}]),
     Target ! {'$graphql_reply', Id, Ref, Data},
     ok.
 

--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -41,14 +41,14 @@
 
 %% TOKENS
 %% -----------------------------------------------------------------------------------
-token(#{ defer_process := Proc }) ->
-    {'$graphql_token', Proc, make_ref()}.
+token(#{ defer_process := Proc, defer_request_id := ReqId }) ->
+    {'$graphql_token', Proc, ReqId, make_ref()}.
 
 %% @private
-token_ref({'$graphql_token', _, Ref}) -> Ref.
+token_ref({'$graphql_token', _, _, Ref}) -> Ref.
 
-reply_cast({'$graphql_token', Target, Ref}, Data) ->
-    Target ! {'$graphql_reply', Ref, Data},
+reply_cast({'$graphql_token', Target, Id, Ref}, Data) ->
+    Target ! {'$graphql_reply', Id, Ref, Data},
     ok.
 
 %% -----------------------------------------------------------------------------------

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -20,7 +20,12 @@ execute(Ctx, #monster { id = ID,
     case Field of
         <<"id">> -> dungeon:wrap({monster, ID});
         <<"name">> ->
-            {ok, Name};
+            NameToken = graphql:token(Ctx),
+            spawn_link(fun() ->
+                               timer:sleep(10),
+                               graphql:reply_cast(NameToken, {ok, Name})
+                       end),
+            {defer, NameToken};
         <<"color">> -> color(Color, Args);
         <<"hitpoints">> -> {ok, HP};
         <<"hp">> -> {ok, HP};

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -27,7 +27,13 @@ execute(Ctx, #monster { id = ID,
                        end),
             {defer, NameToken};
         <<"color">> -> color(Color, Args);
-        <<"hitpoints">> -> {ok, HP};
+        <<"hitpoints">> ->
+            HPToken = graphql:token(Ctx),
+            spawn_link(fun() ->
+                               timer:sleep(20),
+                               graphql:reply_cast(HPToken, {ok, HP})
+                       end),
+            {defer, HPToken};
         <<"hp">> -> {ok, HP};
         <<"inventory">> ->
             Data = [dungeon:load(OID) || OID <- Inventory],
@@ -36,7 +42,12 @@ execute(Ctx, #monster { id = ID,
             {ok, Mood};
         <<"plushFactor">> -> {ok, PlushFactor};
         <<"spikyness">> -> {ok, 5};
-        <<"stats">> -> stats(Stats, Args);
+        <<"stats">> ->
+            StatsToken = graphql:token(Ctx),
+            spawn_link(fun() ->
+                               graphql:reply_cast(StatsToken, stats(Stats, Args))
+                       end),
+            {defer, StatsToken};
         <<"statsVariantOne">> -> stats(Stats);
         <<"statsVariantTwo">> -> stats(Stats);
         <<"statsVariantThree">> -> stats(Stats);

--- a/test/dungeon_stats.erl
+++ b/test/dungeon_stats.erl
@@ -8,10 +8,16 @@ execute(Ctx, #stats { attack = Attack,
                        shell_scripting = ShellScripting},
         Field, _Args) ->
     case Field of
-        <<"attack">> when Attack == 13 ->
-            {ok, null};
         <<"attack">> ->
-            {ok, Attack};
+            AttackToken = graphql:token(Ctx),
+            spawn_link(fun() ->
+                               Reply = case Attack of
+                                           13 -> {ok, null};
+                                           A -> {ok, A}
+                                       end,
+                               graphql:reply_cast(AttackToken, Reply)
+                       end),
+            {defer, AttackToken};
         <<"yell">> ->
             {ok, Yell};
         <<"shellScripting">> ->


### PR DESCRIPTION
This PR constructs a variant of concurrent execution relying on a closure based model.

Whenever we have an operation which is deferred, we wrap the remainder of the computation (i.e., its continuation) into a closure and return the closure. Later, when data arrives for the closure, we invoke it to compute that part of the query. This has a two outcomes:

* The closure completes. We forward the result of the computation to the *upstream* closure which is waiting for a result. If completion like this completes the top level closure, the computation is done.
* The closure returns a new closure and a list of new sub-closures generated. In this case, more data is needed for a full completion and we recurse.

While this is going on, maintain a map of the closures which are currently ongoing. Messages to the mailbox finds an eligible closure and runs it.