### PR TITLE
Remove the use of the {more, _} tuple

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -8,8 +8,6 @@
 -export([err_msg/1]).
 -export([builtin_input_coercer/1]).
 
--define(DEFER_TIMEOUT, 5000). %% @todo: Get rid of this timeout. It is temporary
-
 -type source() :: reference().
 
 -record(done,

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -15,16 +15,16 @@
           key :: binary() | pos_integer() | top_key,
           result :: {ok, term(), [term()]} | {error, [term()]} }).
 
+-record(work,
+        { items :: [{reference(), defer_closure()}] }).
+
 -type defer_closure() ::
-        fun ((term()) ->
-                    #done{} | {more, [{source(), defer_closure()}]}).
+        fun ((term()) -> #done{}
+                       | #work{}).
 
 -record(defer_state,
         { req_id :: source(),
           work = #{} :: #{ source() => defer_closure() } }).
-
--record(work,
-        { items :: [{reference(), defer_closure()}] }).
 
 -spec x(graphql:ast()) -> #{ atom() => graphql:json() }.
 x(X) -> x(#{ params => #{} }, X).
@@ -143,11 +143,11 @@ sset_closure({Upstream, Key}, Self, Missing, Map, Errors) ->
                                result = {ok, NewMap, NewErrors}
                               };
                         _ ->
-                            {more, [{Self,
-                                     sset_closure({Upstream, Key}, Self,
-                                                  NewMissing,
-                                                  NewMap,
-                                                  NewErrors)}]}
+                            #work { items = [{Self,
+                                              sset_closure({Upstream, Key}, Self,
+                                                           NewMissing,
+                                                           NewMap,
+                                                           NewErrors)}]}
                     end
             end
     end.
@@ -322,8 +322,8 @@ execute_field(Path, #{ defer_target := {Upstream, Key},
                                 #done { upstream = Upstream, key = Key, result = {ok, Result, Errs} };
                             {error, Errs} ->
                                 #done { upstream = Upstream, key = Key, result = {error, Errs} };
-                            #work { items = Items } ->
-                                {more, Items}
+                            #work {} = Wrk ->
+                                Wrk
                         end
                 end,
             #work { items = [{Ref, Closure}]};
@@ -582,11 +582,11 @@ list_closure({Upstream, Key}, Self, Missing, List, Done) ->
                                       }
                             end;
                         _ ->
-                            {more, [{Self,
-                                     list_closure({Upstream, Key}, Self,
-                                                  NewMissing,
-                                                  List,
-                                                  NewDone )}]}
+                            #work{ items = [{Self,
+                                             list_closure({Upstream, Key}, Self,
+                                                          NewMissing,
+                                                          List,
+                                                          NewDone )}]}
                     end
             end
     end.
@@ -841,7 +841,7 @@ defer_handle_work(#defer_state {work = WorkMap } = State,
                       State#defer_state { work = WorkMap2 },
                       Upstream,
                       {Key, Value});
-                {more, New} ->
+                #work { items = New } ->
                     NewWork = maps:from_list(New),
                     defer_loop(State#defer_state { work = maps:merge(WorkMap2, NewWork) })
             end


### PR DESCRIPTION
The `#work{}` structure is a far better way. In the future it also lets us propagate monitor/cancellation/timeout sets properly.