### PR TITLE
Implement cancellation

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -955,10 +955,18 @@ defer_handle_cancel(#defer_state { work = WorkMap,
               Rs);
         {Closure, WorkMap2} ->
             #done { result = ok, cancel = ToCancel } = Closure(cancel),
-            defer_handle_cancel(
-              State#defer_state { work = WorkMap2,
-                                  canceled = [R|Cancelled] },
-              ToCancel ++ Rs)
+            case ToCancel of
+                [] ->
+                    defer_handle_cancel(
+                      State#defer_state { work = WorkMap2,
+                                          canceled = [R|Cancelled] },
+                      Rs);
+                _ ->
+                    defer_handle_cancel(
+                      State#defer_state { work = WorkMap2,
+                                          canceled = Cancelled },
+                      ToCancel ++ Rs)
+            end
     end.
             
 

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -22,7 +22,6 @@ execute(Ctx, #monster { id = ID,
         <<"name">> ->
             NameToken = graphql:token(Ctx),
             spawn_link(fun() ->
-                               timer:sleep(10),
                                graphql:reply_cast(NameToken, {ok, Name})
                        end),
             {defer, NameToken};
@@ -30,7 +29,6 @@ execute(Ctx, #monster { id = ID,
         <<"hitpoints">> ->
             HPToken = graphql:token(Ctx),
             spawn_link(fun() ->
-                               timer:sleep(20),
                                graphql:reply_cast(HPToken, {ok, HP})
                        end),
             {defer, HPToken};


### PR DESCRIPTION
Result track whom they want to cancel. Invoke cancellation at the
defer_loop, and recurse through parts of the query which needs to be
cancelled out. If a cancelled reference is already complete, ignore it.