### PR TITLE
Allow to return [] from execute callback as valid object val

### DIFF
--- a/include/graphql.hrl
+++ b/include/graphql.hrl
@@ -1,1 +1,5 @@
 -define(LAZY(X), {'$lazy', fun() -> X end}).
+
+%% Only for not found behaviours
+-define(RETURN_NULL, {ok, null}).
+-define(RETURN_EMPTY_LIST, {ok, []}).

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -368,7 +368,7 @@ field_closure(Path, #{ defer_target := Upstream } = Ctx,
                 end
         end,
     #work { items = [{Ref, Closure}]}.
-    
+
 
 resolve_field_value(Ctx, #object_type { id = OID, annotations = OAns} = ObjectType, Value, Name, FAns, Fun, Args) ->
     CtxAnnot = Ctx#{
@@ -597,7 +597,7 @@ list_closure(Upstream, Self, Missing, List, Done) ->
               };
         ({change_ref, From, To}) ->
             {Val, Removed} = maps:take(From, Missing),
-            #work { items = [{Self, 
+            #work { items = [{Self,
                               list_closure(Upstream, Self,
                                            Removed#{ To => Val },
                                            List,
@@ -666,7 +666,7 @@ not_null_closure(Upstream, Self, Path, Ref) ->
                result = Res
               }
     end.
-    
+
 complete_list_value_result([]) ->
     {[], []};
 complete_list_value_result([{error, Err}|Next]) ->
@@ -725,11 +725,16 @@ resolver_function(#object_type { resolve_module = undefined }, undefined) ->
 resolver_function(#object_type { resolve_module = M }, undefined) ->
     fun M:execute/4.
 
-default_resolver(_, none, _) -> {error, no_object};
-default_resolver(_, undefined, _) -> {error, undefined_object};
+default_resolver(_, none, _) ->
+    {error, no_object};
+default_resolver(_, undefined, _) ->
+    {error, undefined_object};
 default_resolver(_, null, _) ->
     %% A Null value is a valid object value
     {ok, null};
+default_resolver(_, [], _) ->
+    %% A empty list [] value is a valid object value
+    {ok, []};
 default_resolver(#{ field := Field}, Cur, _Args) ->
     case maps:get(Field, Cur, not_found) of
         {'$lazy', F} when is_function(F, 0) -> F();
@@ -893,10 +898,10 @@ defer_loop(#defer_state { req_id = Id } = State) ->
 
 %% Cancel a token
 cancel(_Token, []) -> ok;
-cancel(Token, [Pid|Pids]) -> 
+cancel(Token, [Pid|Pids]) ->
     Pid ! {graphql_cancel, Token},
     cancel(Token, Pids).
-    
+
 %% Process work
 defer_handle_work(#defer_state {work = WorkMap,
                                 canceled = Cancelled } = State,
@@ -947,7 +952,7 @@ defer_handle_work(#defer_state {work = WorkMap,
 
 defer_handle_cancel(State, []) -> State;
 defer_handle_cancel(#defer_state { work = WorkMap,
-                                   canceled = Cancelled } = State, [R|Rs]) -> 
+                                   canceled = Cancelled } = State, [R|Rs]) ->
     case maps:take(R, WorkMap) of
         error ->
             defer_handle_cancel(
@@ -968,7 +973,7 @@ defer_handle_cancel(#defer_state { work = WorkMap,
                       ToCancel ++ Rs)
             end
     end.
-            
+
 
 %% -- ERROR HANDLING --
 

--- a/test/star_wars.erl
+++ b/test/star_wars.erl
@@ -34,7 +34,7 @@ inject() ->
 
          } } },
     ok = graphql:insert_schema_definition(Query),
-    
+
     Root = {root, #{
     	query => 'Query',
     	interaces => []
@@ -140,7 +140,7 @@ get_character(ID) ->
 
 get_friends(#{ <<"friends">> := Friends }) ->
     {ok, [get_character(F) || F <- Friends]}.
-    
+
 get_hero(_Ctx, #{ <<"episode">> := {enum, <<"EMPIRE">>} }) ->
     {Humans, _} = star_wars(),
     {ok, maps:get(<<"1000">>, Humans)};
@@ -166,7 +166,7 @@ star_wars() ->
     Vader = #{
     	id => <<"1001">>,
     	name => <<"Darth Vader">>,
-    	friends => <<"1004">>,
+    	friends => [<<"1004">>],
     	appearsIn => resolve_module([ 4, 5, 6 ]),
     	homePlanet => <<"Tatooine">> },
     Han = #{
@@ -185,7 +185,7 @@ star_wars() ->
     	name => <<"Wilhuff Tarkin">>,
     	friends => [ <<"1001">> ],
     	appearsIn => resolve_module([ 4 ]) },
-    
+
     HumanData = #{
     	<<"1000">> => c(Luke),
     	<<"1001">> => c(Vader),
@@ -193,7 +193,7 @@ star_wars() ->
     	<<"1003">> => c(Leia),
     	<<"1004">> => c(Tarkin)
     },
-    
+
     Threepio = #{
     	id => <<"2000">>,
     	name => <<"C-3PO">>,
@@ -201,7 +201,7 @@ star_wars() ->
     	appearsIn => resolve_module([ 4, 5, 6 ]),
     	primaryFunction => <<"Protocol">>
     },
-    
+
     Artoo = #{
     	id => <<"2001">>,
     	name => <<"R2-D2">>,
@@ -209,12 +209,12 @@ star_wars() ->
     	appearsIn => resolve_module([ 4, 5, 6 ]),
     	primaryFunction => <<"AstroMech">>
     },
-    	
+
     DroidData = #{
     	<<"2000">> => c(Threepio),
     	<<"2001">> => c(Artoo)
     },
-    
+
     {HumanData, DroidData}.
 
 c(M) ->


### PR DESCRIPTION
Allow to return `{ok, []}` [in the same way we are returning `{ok, null}`](https://github.com/shopgun/graphql-erlang/compare/dc/not-found/empty.list?expand=1#diff-53b775494385f03a4e036c2c90a6402dR732) at execute callback and make this return more explicit using  `?RETURN_NULL` and `?RETURN_EMPTY_LIST` macros

**execute/4 example**
```erlang
execute(Ctx, Cur, <<"planningSuggestions">>, Args) ->
   {ok, []}; %% it will be replaced with ?RETURN_EMPTY_LIST;
..
.
```
**output:**
```json
{
  "data": {
    "planningSuggestions": []
  }
}
```