### PR TITLE
Handle coercion of default values

### DIFF
--- a/test/dungeon.erl
+++ b/test/dungeon.erl
@@ -74,13 +74,14 @@ reserve_number(Input) ->
 
 create(monster, Opts) ->
     Name = proplists:get_value(name, Opts, <<"goblin">>),
-    Mood = proplists:get_value(mood, Opts, "dodgy"),
+    Mood = proplists:get_value(mood, Opts, 'DODGY'),
+    true = is_atom(Mood),
     Color = proplists:get_value(color, Opts, #{ r => 65, g => 146, b => 75}),
     HitPoints = proplists:get_value(hitpoints, Opts, 10),
     #monster { name = Name
              , color = Color
              , hitpoints = HitPoints
-             , mood = {enum, #{ mood => Mood }}
+             , mood = Mood
              , stats = [#stats{}] };
 create(room, Opts) ->
     Desc = proplists:get_value(desc, Opts, <<"hallway">>),
@@ -151,17 +152,17 @@ populate() ->
           [ {create(monster, [ {name, <<"goblin">>}
                              , {color, #{ r => 65, g => 146, b => 75}}
                              , {hitpoints, 10}
-                             , {mood, {enum, #{ mood => "dodgy" }}}
+                             , {mood, 'DODGY'}
                              ]), insert}
           , {create(monster, [ {name, <<"orc">>}
                              , {color, #{ r => 65, g => 146, b => 75}}
                              , {hitpoints, 30}
-                             , {mood, {enum, #{ mood => "aggressive" }}}
+                             , {mood, 'AGGRESSIVE'}
                              ]), insert}
           , {create(monster, [ {name, <<"reserved goblin">>}
                              , {color, #{ r => 65, g => 146, b => 75}}
                              , {hitpoints, 5}
-                             , {mood, {enum, #{ mood => "dodgy" }}}
+                             , {mood, 'DODGY'}
                              ]), reserve}
           ]
      },

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -262,7 +262,7 @@ scalar_output_coercion(Config) ->
 
 replace_enum_representation(Config) ->
     ct:log("Test replace enum representation"),
-    Monster = dungeon:create(monster, [{mood, "dodgy"}]),
+    Monster = dungeon:create(monster, [{mood, 'DODGY'}]),
     [{GoblinId, _Goblin}] = dungeon:batch_create([{Monster, insert}]),
     OpaqueId = dungeon:opaque_id(GoblinId),
     #{ data := #{

--- a/test/dungeon_enum.erl
+++ b/test/dungeon_enum.erl
@@ -3,28 +3,12 @@
 -export([input/2,
 	 output/2]).
 
-bintolower(X) ->
-    string:to_lower(
-      binary_to_list(X)).
-
 input(<<"Mood">>, <<Bin/bitstring>>) ->
-    StrMood = bintolower(Bin),
-    {ok, {enum, #{ mood => StrMood }}};
+    {ok, binary_to_existing_atom(Bin, utf8)};
 input(<<"Mood">>, X) ->
     {error, {invalid_mood, X}}.
 
-output(<<"Mood">>, <<"DODGY">>) ->
-    {ok, <<"DODGY">>};
-output(<<"Mood">>, #{ mood := Mood }) ->
-    case Mood of 
-        "tranquil"  -> {ok, <<"TRANQUIL">>};
- 	"dodgy"  -> {ok, <<"DODGY">>};
- 	"aggressive"  -> {ok, <<"AGGRESSIVE">>};
- 	_ -> {error, {invalid_mood}}
-    end.
-
-
-
-    
-
+output(<<"Mood">>, 'DODGY') -> {ok, <<"DODGY">>};
+output(<<"Mood">>, 'TRANQUIL') -> {ok, <<"TRANQUIL">>};
+output(<<"Mood">>, 'AGGRESSIVE') -> {ok, <<"AGGRESSIVE">>}.
 

--- a/test/dungeon_mutation.erl
+++ b/test/dungeon_mutation.erl
@@ -21,7 +21,11 @@ execute(_Ctx, _, <<"introduceMonster">>, #{ <<"input">> := Input }) ->
        <<"plushFactor">> := PF
     } = Input,
     Ss = input_stats(Stats),
-    {enum, _} = M,
+    case is_atom(M) of
+        true -> ok;
+        false ->
+            exit({bad_mood_value, M})
+    end,
     {atomic, Monster} = dungeon:insert(#monster {
     	properties = Props,
     	plush_factor = PF,

--- a/test/dungeon_query.erl
+++ b/test/dungeon_query.erl
@@ -18,7 +18,7 @@ execute(_Ctx, _, <<"monsters">>, #{ <<"ids">> := InputIDs }) ->
           end || ID <- InputIDs]};
 execute(_Ctx, _, <<"findMonsters">>, #{ <<"moods">> := Moods }) ->
     QH = qlc:q([M || M <- mnesia:table(monster),
-                     mood_member(Moods, M#monster.mood)]),
+                     lists:member(M#monster.mood, Moods)]),
     Monsters = dungeon:load_txn(QH),
     {ok, [{ok, M} || M <- Monsters]};
 execute(_Ctx, _, <<"thing">>, #{ <<"id">> := InputID }) ->
@@ -37,9 +37,3 @@ execute(_Ctx, _, <<"rooms">>, #{ <<"ids">> := InputIDs }) ->
               dungeon:dirty_load(OID)
           end || ID <- InputIDs]}.
 
-mood_member(Moods, {enum, #{ mood := Value }}) ->
-    error_logger:info_report([
-                              {moods, Moods},
-                              {value, Value}]),
-    M = iolist_to_binary(string:to_upper(Value)),
-    lists:member(M, Moods).


### PR DESCRIPTION
Change the dungeon such that every enumeration is an atom internally.
Observe that parameter-passed values do not enjoy being fed through
the enumeration module resolver. This is obviously a problem which
needs some addressing. In this patch, we currently detect the problem,
but we don't provide a fix yet.