### PR TITLE
Provide validations which are low-hanging fruits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ the compatibility issues you are likely to encounter.
 ### Changed
 - Format type values as binary() in error's messages
   (Minor fix)
+- Introduce Validation 5.7.1
+- Introduce Validation 5.5.1
+- Introduce Validation 5.6.1
+- Introduce Validation 5.6.2
+- Introduce Validation 5.6.3
 
 ## [0.11.1] 2017-10-26
 

--- a/src/graphql_ast.erl
+++ b/src/graphql_ast.erl
@@ -3,7 +3,7 @@
 -include("graphql_internal.hrl").
 -include("graphql_schema.hrl").
 
--export([name/1, id/1, typename/1]).
+-export([name/1, id/1, typename/1, uniq/1]).
 
 -spec name('ROOT' | name()) -> binary().
 name('ROOT') -> <<"ROOT">>;
@@ -30,4 +30,15 @@ typename(#union_type { id = ID }) -> ID;
 typename(#scalar_type { id = ID }) -> ID;
 typename(#input_object_type { id = ID }) -> ID;
 typename(#object_type { id = ID }) -> ID.
+
+%% Determine if an association list has unique keys
+%% Assumes an already sorted list (for now)
+-spec uniq([{term(), term()}]) -> ok | {not_unique, term()}.
+uniq(L) ->
+    uniq_(lists:sort(L)).
+
+uniq_([]) -> ok;
+uniq_([_]) -> ok;
+uniq_([{X, _}, {X, _} | _]) -> {not_unique, X};
+uniq_([_ | Next]) -> uniq_(Next).
 

--- a/src/graphql_ast.erl
+++ b/src/graphql_ast.erl
@@ -21,7 +21,8 @@ id_(#op { id = ID }) -> ID;
 id_(#field { id = ID }) -> ID;
 id_(#frag_spread { id = ID }) -> ID;
 id_(#frag { id = ID }) -> ID;
-id_(#vardef { id = ID }) -> ID.
+id_(#vardef { id = ID }) -> ID;
+id_(#directive { id = ID }) -> ID.
      
 typename(#enum_type { id = ID }) -> ID;
 typename(#interface_type { id = ID }) -> ID;

--- a/src/graphql_ast.erl
+++ b/src/graphql_ast.erl
@@ -32,7 +32,6 @@ typename(#input_object_type { id = ID }) -> ID;
 typename(#object_type { id = ID }) -> ID.
 
 %% Determine if an association list has unique keys
-%% Assumes an already sorted list (for now)
 -spec uniq([{term(), term()}]) -> ok | {not_unique, term()}.
 uniq(L) ->
     uniq_(lists:sort(L)).

--- a/src/graphql_builtins.erl
+++ b/src/graphql_builtins.erl
@@ -33,6 +33,7 @@ standard_types_inject() ->
 directive_schema(include) ->
     #directive_type {
        id = <<"include">>,
+       locations = [field, fragment_spread, inline_fragment],
        args = #{
          <<"if">> =>
              #schema_arg{
@@ -43,6 +44,7 @@ directive_schema(include) ->
 directive_schema(skip) ->
     #directive_type {
        id = <<"skip">>,
+       locations = [field, fragment_spread, inline_fragment],
        args = #{
          <<"if">> =>
              #schema_arg{

--- a/src/graphql_elaborate.erl
+++ b/src/graphql_elaborate.erl
@@ -174,7 +174,7 @@ directives(Path, Ds) ->
         [directive(Path, D) || D <- Ds]
     catch
         throw:{unknown, Unknown} ->
-            err(Path, {unknown_directive, Unknown})
+            err(Path, {unknown_directive, graphql_ast:id(Unknown)})
     end.
 
 directive(Path, #directive{ id = ID, args = Args } = D) ->

--- a/src/graphql_elaborate.erl
+++ b/src/graphql_elaborate.erl
@@ -204,7 +204,7 @@ directive(Path, Context, #directive{ id = ID, args = Args } = D) ->
             D#directive { args = field_args([D | Path], Args, SArgs),
                           schema = Schema };
         false ->
-            err(Path, {invalid_directive_location, ID, Context})
+            err(Path, {invalid_directive_location, graphql_ast:name(ID), Context})
     end.
 
 %% -- SELECTION SETS -------------------------------

--- a/src/graphql_introspection.erl
+++ b/src/graphql_introspection.erl
@@ -398,7 +398,7 @@ inject() ->
                              'MUTATION' => #{ value => 2, description => "Mutations" },
                              'FIELD' => #{ value => 3, description => "Fields" },
                              'FRAGMENT_DEFINITION' => #{ value => 4, description => "Fragment definitions" },
-                             'FRAGMENT_SPREADS' => #{ value => 5, description => "Fragment spreads" },
+                             'FRAGMENT_SPREAD' => #{ value => 5, description => "Fragment spread" },
                              'INLINE_FRAGMENT' => #{ value => 6, description => "Inline fragments" }
                             }}},
     ok = graphql:insert_schema_definition(DirectiveLocation),
@@ -411,6 +411,8 @@ inject() ->
     ok = graphql:insert_schema_definition(Schema),
     ok.
 
+%% @todo: Look up the directive in the schema and then use that lookup as a way to render the
+%% following part. Most notably, locations can be mapped from the directive type.
 directive(Kind) ->
     {Name, Desc} =
         case Kind of
@@ -427,7 +429,7 @@ directive(Kind) ->
        <<"name">> => Name,
        <<"description">> => Desc,
        <<"locations">> =>
-           [<<"FIELD">>, <<"FRAGMENT_SPREADS">>, <<"INLINE_FRAGMENT">>],
+           [<<"FIELD">>, <<"FRAGMENT_SPREAD">>, <<"INLINE_FRAGMENT">>],
        <<"args">> =>
            [#{ <<"name">> => <<"if">>,
                <<"description">> => <<"flag for the condition">>,

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -461,7 +461,8 @@ g_string({bstring, _, S}) -> S.
 g_bool({bool, _, B}) -> B.
 
 g_list(L) when is_list(L) -> L.
-g_input_object(KVPairs) -> maps:from_list(KVPairs).
+g_input_object(KVPairs) ->
+    {input_object, KVPairs}.
 
 %% Convert keywords into binaries if they don't occur in the KW-position
 keyword({A, Line}) when is_atom(A) ->

--- a/src/graphql_schema.hrl
+++ b/src/graphql_schema.hrl
@@ -12,6 +12,9 @@
 
 -type resolver_args() :: #{ binary() => term() }.
 -type ctx() :: #{ atom() => term() }.
+-type location() :: query | mutation | field
+                  | fragment_definition | fragment_spread | inline_fragment.
+
 -type resolver() :: fun ((ctx, term(), resolver_args()) -> term()).
 
 -record(enum_value,
@@ -58,6 +61,7 @@
 
 -record(directive_type,
         { id :: binary(),
+          locations :: [location()],
           args = #{} :: #{ binary() => schema_arg() }
         }).
 -type directive_type() :: #directive_type{}.

--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -286,7 +286,7 @@ frag(Ctx, Path, #frag {selection_set = SSet} = Frag) ->
 op_unique_varenv(VDefs) ->
     NamedVars = [{graphql_ast:name(K), V}
                  || #vardef { id = K } = V <- VDefs],
-    uniq(lists:sort(NamedVars)).
+    graphql_ast:uniq(NamedVars).
 
 %% Type check an operation.
 op(Ctx, Path, #op { id = ID, vardefs = VDefs, selection_set = SSet} = Op) ->
@@ -367,7 +367,7 @@ directive(Ctx, Path,
 %% to the schema arguments.
 args(Ctx, Path, Args, Schema) ->
     NamedArgs = [{graphql_ast:name(K), V} || {K, V} <- Args],
-    case uniq(lists:sort(NamedArgs)) of
+    case graphql_ast:uniq(NamedArgs) of
         ok ->
           SchemaArgs = maps:to_list(Schema),
           args(Ctx, Path, NamedArgs, SchemaArgs, []);
@@ -539,24 +539,13 @@ coerce_input_object(Path, {input_object, Elems}) ->
                      N = coerce_name(K),
                      {N, coerce_input_object([N | Path], V)}
                  end || {K, V} <- Elems],
-    case uniq(lists:sort(AssocList)) of
+    case graphql_ast:uniq(AssocList) of
         ok ->
             maps:from_list(AssocList);
         {not_unique, Key} ->
             err(Path, {input_object_not_unique, Key})
     end;
 coerce_input_object(_Path, Value) -> Value.
-
-
-%% -- Internal functions --------------------------------
-
-%% Determine if an association list has unique keys
--spec uniq([{term(), term()}]) -> ok | {not_unique, term()}.
-uniq([]) -> ok;
-uniq([_]) -> ok;
-uniq([{X, _}, {X, _} | _]) -> {not_unique, X};
-uniq([_ | Next]) -> uniq(Next).
-
 
 %% -- Error handling -------------------------------------
 

--- a/test/schema_pet.erl
+++ b/test/schema_pet.erl
@@ -3,6 +3,14 @@
 -export([inject/0]).
 
 inject() ->
+    TestField = {input_object, #{
+                   id => <<"InputTest">>,
+                   description => ["Input Object for testing uniqueness"],
+                   fields => #{
+                     field => #{
+                       type => 'Bool!',
+                       description => "A bool field" }}}},
+    ok = graphql:insert_schema_definition(TestField),
     DogCommand = {enum, #{
     	id => 'DogCommand',
     	description => "Things you can command your dog to do",
@@ -183,17 +191,26 @@ inject() ->
     }}},
     ok = graphql:insert_schema_definition(Arguments),
 
-    QueryRoot = {object, #{
-    	id => 'QueryRoot',
-    	description => "Root Query of the pet schema",
-    	fields => #{
-    		arguments => #{ type => 'Arguments', description => "More complicated Argument cases" },
-    		dog => #{ type => 'Dog', description => "Query of dogs" },
-    		human => #{ type => 'Human', description => "Query of humans" },
-    		pet => #{ type => 'Pet', description => "Query of pets" },
-    		catOrDog => #{ type => 'CatOrDog', description => "Query of cats or dogs" }
-    	}
-    }},
+    QueryRoot =
+        {object, #{
+           id => 'QueryRoot',
+           description => "Root Query of the pet schema",
+           fields => #{
+             arguments => #{ type => 'Arguments', description => "More complicated Argument cases" },
+             field =>
+                 #{ type => 'Bool',
+                    description => "Test for input object uniqueness",
+                    args => #{
+                      arg => #{
+                        type => 'InputTest',
+                        description => "An input object test field"
+                       }}},
+             dog => #{ type => 'Dog', description => "Query of dogs" },
+             human => #{ type => 'Human', description => "Query of humans" },
+             pet => #{ type => 'Pet', description => "Query of pets" },
+             catOrDog => #{ type => 'CatOrDog', description => "Query of cats or dogs" }
+            }
+          }},
     ok = graphql:insert_schema_definition(QueryRoot),
     
     Schema = {root, #{

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -18,6 +18,7 @@
          v_5_4_2_2/1,
          v_5_4_2_3_1/1,
          v_5_5_1/1,
+         v_5_6_1/1,
          v_5_7_1/1,
          v_5_7_3/1
         ]).
@@ -66,6 +67,7 @@ groups() ->
            v_5_4_2_2,
            v_5_4_2_3_1,
            v_5_5_1,
+           v_5_6_1,
            v_5_7_1,
            v_5_7_3
          ]},
@@ -247,6 +249,11 @@ v_5_4_2_3_1(_Config) ->
 
 v_5_5_1(_Config) ->
     false = th:v("{ field(arg: { field: true, field: false })}"),
+    ok.
+
+v_5_6_1(_Config) ->
+    false = th:v("query Q { dog { name @invalidDirective }}"),
+    true  = th:v("query Q { dog { name @include(if: true) }}"),
     ok.
 
 v_5_7_1(_Config) ->

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -20,6 +20,7 @@
          v_5_5_1/1,
          v_5_6_1/1,
          v_5_6_2/1,
+         v_5_6_3/1,
          v_5_7_1/1,
          v_5_7_3/1
         ]).
@@ -70,6 +71,7 @@ groups() ->
            v_5_5_1,
            v_5_6_1,
            v_5_6_2,
+           v_5_6_3,
            v_5_7_1,
            v_5_7_3
          ]},
@@ -260,6 +262,10 @@ v_5_6_1(_Config) ->
 
 v_5_6_2(_Config) ->
     false = th:v("query Q @skip(if: $foo) { dog { name }}"),
+    ok.
+
+v_5_6_3(_Config) ->
+    false = th:v("query Q { dog { name @skip(if: true) @skip(if: false) }}"),
     ok.
 
 v_5_7_1(_Config) ->

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -17,6 +17,7 @@
          v_5_4_2_1/1,
          v_5_4_2_2/1,
          v_5_4_2_3_1/1,
+         v_5_5_1/1,
          v_5_7_1/1,
          v_5_7_3/1
         ]).
@@ -64,6 +65,7 @@ groups() ->
            v_5_4_2_1,
            v_5_4_2_2,
            v_5_4_2_3_1,
+           v_5_5_1,
            v_5_7_1,
            v_5_7_3
          ]},
@@ -243,15 +245,19 @@ v_5_4_2_3_1(_Config) ->
 
    ok.
 
+v_5_5_1(_Config) ->
+    false = th:v("{ field(arg: { field: true, field: false })}"),
+    ok.
+
 v_5_7_1(_Config) ->
     false = th:v("query houseTrainedQuery("
                  " $atOtherHomes: Boolean,"
                  " $atOtherHomes: Boolean) { "
-                 "dog { isHousetrained(atOtherHomes: $atOtherHomes) } }"),
+                 "dog { isHouseTrained(atOtherHomes: $atOtherHomes) } }"),
     Q = "query A($atOtherHomes: Boolean) {...HouseTrainedFragment } "
         "query B($atOtherHomes: Boolean) {...HouseTrainedFragment } "
         " fragment HouseTrainedFragment { "
-        "    dog {isHousetrained(atOtherHomes: $atOtherHomes)}}",
+        "    dog {isHouseTrained(atOtherHomes: $atOtherHomes)}}",
     
     %% Since we have not yet solved fragment expansion correctly, this
     %% query doesn't work. But once fragment expansion is solved, then

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -17,6 +17,7 @@
          v_5_4_2_1/1,
          v_5_4_2_2/1,
          v_5_4_2_3_1/1,
+         v_5_7_1/1,
          v_5_7_3/1
         ]).
 
@@ -63,6 +64,7 @@ groups() ->
            v_5_4_2_1,
            v_5_4_2_2,
            v_5_4_2_3_1,
+           v_5_7_1,
            v_5_7_3
          ]},
     [Validation].
@@ -241,7 +243,23 @@ v_5_4_2_3_1(_Config) ->
 
    ok.
 
-v_5_7_3(_Confgi) ->
+v_5_7_1(_Config) ->
+    false = th:v("query houseTrainedQuery("
+                 " $atOtherHomes: Boolean,"
+                 " $atOtherHomes: Boolean) { "
+                 "dog { isHousetrained(atOtherHomes: $atOtherHomes) } }"),
+    Q = "query A($atOtherHomes: Boolean) {...HouseTrainedFragment } "
+        "query B($atOtherHomes: Boolean) {...HouseTrainedFragment } "
+        " fragment HouseTrainedFragment { "
+        "    dog {isHousetrained(atOtherHomes: $atOtherHomes)}}",
+    
+    %% Since we have not yet solved fragment expansion correctly, this
+    %% query doesn't work. But once fragment expansion is solved, then
+    %% we should expect a true return here over a false one.
+    false = th:v(Q),
+    ok.
+
+v_5_7_3(_Config) ->
     false = th:v("query Q($var : Pet) { dog { name } }"),
     false = th:v("query Q($var : Dog) { dog { name } }"),
     true  = th:v(

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -19,6 +19,7 @@
          v_5_4_2_3_1/1,
          v_5_5_1/1,
          v_5_6_1/1,
+         v_5_6_2/1,
          v_5_7_1/1,
          v_5_7_3/1
         ]).
@@ -68,6 +69,7 @@ groups() ->
            v_5_4_2_3_1,
            v_5_5_1,
            v_5_6_1,
+           v_5_6_2,
            v_5_7_1,
            v_5_7_3
          ]},
@@ -254,6 +256,10 @@ v_5_5_1(_Config) ->
 v_5_6_1(_Config) ->
     false = th:v("query Q { dog { name @invalidDirective }}"),
     true  = th:v("query Q { dog { name @include(if: true) }}"),
+    ok.
+
+v_5_6_2(_Config) ->
+    false = th:v("query Q @skip(if: $foo) { dog { name }}"),
     ok.
 
 v_5_7_1(_Config) ->


### PR DESCRIPTION
Target simpler validations, which are easy to pluck right away. Use these to solve some of the simpler issues in the repository.