### PR TITLE
Implement validation 5.4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ the compatibility issues you are likely to encounter.
 - Introduce Validation 5.6.1
 - Introduce Validation 5.6.2
 - Introduce Validation 5.6.3
+- Introduce a checker for fragment expansions. This disallows any
+  fragment expansion which can never match in a given context as an
+  error. Fragments which *may* be expanded are accepted.
+- Introduce validation checks for fragment expansions from the
+  specification.
 
 ## [0.11.1] 2017-10-26
 

--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -42,6 +42,7 @@ err_key(uncategorized, Key) -> Key.
 path(Path) ->
    F = fun
            F('ROOT') -> <<"ROOT">>;
+           F('...') -> <<"...">>;
            F(document) -> <<"document">>;
            F(#frag { id = ID }) -> name(ID);
            F(#op { id = ID }) -> name(ID);

--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -329,7 +329,7 @@ field(#{ fragenv := FE } = Ctx, Path, ScopeTy, #frag_spread { id = ID, directive
         not_found ->
             err([Name | Path], unknown_fragment);
         #frag { schema = FragTy } ->
-            ok = fragment_embed(FragTy, ScopeTy),
+            ok = fragment_embed([Name | Path], FragTy, ScopeTy),
             %% You can always include a fragspread, as long as it exists
             %% It may be slightly illegal in a given context but this just
             %% means the system will ignore the fragment on execution
@@ -339,7 +339,7 @@ field(Ctx, Path, Scope, #frag { id = '...',
                                 schema = InnerScope,
                                 selection_set = SSet,
                                 directives = Ds} = InlineFrag) ->
-    ok = fragment_embed(InnerScope, Scope),
+    ok = fragment_embed(['...' | Path], InnerScope, Scope),
     InlineFrag#frag {
         directives = directives(Ctx, [InlineFrag | Path], Ds),
         selection_set = sset(Ctx, [InlineFrag | Path], InnerScope, SSet)
@@ -432,7 +432,7 @@ take_arg(Args, {Key, #schema_arg { ty = Ty, default = Default }}) ->
 %% We proceed by computing the valid set of the Scope and also the
 %% Valid set of the fragment. The intersection type between these two,
 %% Scope and Spread, must not be the empty set. Otherwise it is a failure.
-fragment_embed(SpreadTy, ScopeTy) ->
+fragment_embed(_Path, SpreadTy, ScopeTy) ->
     error_logger:info_report([{spread, SpreadTy}, {scope, ScopeTy}]),
     ok.
 

--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -459,8 +459,8 @@ fragment_embed(Path, #object_type { id = SpreadTy },
     %% Object spread in Object scope requires a perfect match
     err(Path, {fragment_spread, SpreadTy, ScopeTy});
 fragment_embed(Path, #object_type { id = ID },
-                      #union_type { id = UID,
-                                    types = ScopeTypes }) ->
+                     #union_type { id = UID,
+                                   types = ScopeTypes }) ->
     case lists:member(ID, ScopeTypes) of
         true -> ok;
         false -> err(Path, {not_union_member, ID, UID})
@@ -527,10 +527,7 @@ fragment_embed(Path, #union_type { id = SpreadID, types = SpreadMembers },
             ok;
         [] ->
             err(Path, {no_common_object, SpreadID, ScopeID})
-    end;
-fragment_embed(_Path, SpreadType, ScopeType) ->
-    exit({wrong_invocation, SpreadType, ScopeType}).
-
+    end.
 
 %% Decide if a type is an valid embedding in another type. We assume
 %% that the first parameter is the 'D' type and the second parameter

--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -351,7 +351,7 @@ field(Ctx, Path, _Scope,
          args = Args,
          selection_set = SSet,
          directives = Ds,
-         schema = #schema_field { args = SArgs } = InnerScope} = F) ->
+         schema = #schema_field { args = SArgs, ty = InnerScope }} = F) ->
     F#field { args = args(Ctx, [F | Path], Args, SArgs),
               directives = directives(Ctx, [F | Path], Ds),
               selection_set = sset(Ctx, [F | Path], InnerScope, SSet) }.

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -153,14 +153,17 @@ v_5_3_1(_Config) ->
     true = th:v(
       "{ dog { ...F } } fragment F on Dog { doesKnowCommand(dogCommand: SIT) }"),
 
+    true = th:v(
+      "{ dog { ...F } } fragment F on Dog { isHouseTrained(atOtherHomes: true) @include(if: true) }"),
+
     false = th:v(
       "{ dog { ...F } } fragment F on Dog { doesKnowCommand(command: CLEAN_UP_HOUSE) }"),
 
     true = th:v(
-      "{ dog { ...F } } fragment F on Arguments { multipleReqs(x: 1, y: 2) }"),
+      "{ arguments { ...F } } fragment F on Arguments { multipleReqs(x: 1, y: 2) }"),
 
     true = th:v(
-      "{ dog { ...F } } fragment F on Arguments { multipleReqs(y:1, x: 2) }"),
+      "{ arguments { ...F } } fragment F on Arguments { multipleReqs(y:1, x: 2) }"),
 
     ok.
 

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -17,6 +17,7 @@
          v_5_4_2_1/1,
          v_5_4_2_2/1,
          v_5_4_2_3_1/1,
+         v_5_4_2_3_2/1,
          v_5_5_1/1,
          v_5_6_1/1,
          v_5_6_2/1,
@@ -66,6 +67,7 @@ groups() ->
            v_5_4_2_1,
            v_5_4_2_2,
            v_5_4_2_3_1,
+           v_5_4_2_3_2,
            v_5_5_1,
            v_5_6_1,
            v_5_6_2,
@@ -251,6 +253,15 @@ v_5_4_2_3_1(_Config) ->
      "{ dog { ...F } } fragment F on Dog { ... on Cat { meowVolume } }"),
 
    ok.
+
+v_5_4_2_3_2(_Config) ->
+    true = th:v(
+             "{ dog { ...petFrag } } fragment petFrag on Pet { name }"),
+    true = th:v(
+      "{ dog { ...unionWithObjectFragment } } "
+      "fragment catOrDogNameFragment on CatOrDog { ... on Cat { meowVolume } } "
+      "fragment unionWithObjectFragment on Dog { ...catOrDogNameFragment }"),
+    ok.
 
 v_5_5_1(_Config) ->
     false = th:v("{ field(arg: { field: true, field: false })}"),

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -280,11 +280,11 @@ v_5_4_2_3_3(_Config) ->
 
 v_5_4_2_3_4(_Config) ->
     true = th:v(
-       "{ dog { ...dogOrHumanFragment } } "
+       "{ dog { ...unionWithInterface } } "
        "fragment unionWithInterface on Pet {...dogOrHumanFragment} "
        "fragment dogOrHumanFragment on DogOrHuman {... on Dog {barkVolume}}"),
     false = th:v(
-       "{ human { ...sentientFragment } } "
+       "{ human { ...nonIntersectingInterfaces } } "
        "fragment nonIntersectingInterfaces on Pet {...sentientFragment} "
        "fragment sentientFragment on Sentient {name}"),
     ok.

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -45,8 +45,6 @@ end_per_suite(_Config) ->
     application:stop(graphql),
     ok.
 
-init_per_testcase(v_5_4_2_3_1, _Config) ->
-    {skip, needs_more_validation};
 init_per_testcase(_Case, Config) ->
     Config.
 

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -19,6 +19,7 @@
          v_5_4_2_3_1/1,
          v_5_4_2_3_2/1,
          v_5_4_2_3_3/1,
+         v_5_4_2_3_4/1,
          v_5_5_1/1,
          v_5_6_1/1,
          v_5_6_2/1,
@@ -70,6 +71,7 @@ groups() ->
            v_5_4_2_3_1,
            v_5_4_2_3_2,
            v_5_4_2_3_3,
+           v_5_4_2_3_4,
            v_5_5_1,
            v_5_6_1,
            v_5_6_2,
@@ -274,6 +276,17 @@ v_5_4_2_3_3(_Config) ->
               "{ human { ...humanOrAlienFragment }} "
               "fragment sentientFragment on Sentient {... on Dog {barkVolume}} "
               "fragment humanOrAlienFragment on HumanOrAlien {... on Cat {meowVolume}}"),
+    ok.
+
+v_5_4_2_3_4(_Config) ->
+    true = th:v(
+       "{ dog { ...dogOrHumanFragment } } "
+       "fragment unionWithInterface on Pet {...dogOrHumanFragment} "
+       "fragment dogOrHumanFragment on DogOrHuman {... on Dog {barkVolume}}"),
+    false = th:v(
+       "{ human { ...sentientFragment } } "
+       "fragment nonIntersectingInterfaces on Pet {...sentientFragment} "
+       "fragment sentientFragment on Sentient {name}"),
     ok.
 
 v_5_5_1(_Config) ->

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -18,6 +18,7 @@
          v_5_4_2_2/1,
          v_5_4_2_3_1/1,
          v_5_4_2_3_2/1,
+         v_5_4_2_3_3/1,
          v_5_5_1/1,
          v_5_6_1/1,
          v_5_6_2/1,
@@ -68,6 +69,7 @@ groups() ->
            v_5_4_2_2,
            v_5_4_2_3_1,
            v_5_4_2_3_2,
+           v_5_4_2_3_3,
            v_5_5_1,
            v_5_6_1,
            v_5_6_2,
@@ -261,6 +263,17 @@ v_5_4_2_3_2(_Config) ->
       "{ dog { ...unionWithObjectFragment } } "
       "fragment catOrDogNameFragment on CatOrDog { ... on Cat { meowVolume } } "
       "fragment unionWithObjectFragment on Dog { ...catOrDogNameFragment }"),
+    ok.
+
+v_5_4_2_3_3(_Config) ->
+    true = th:v(
+             "{ dog { ...catOrDogFragment } } "
+             "fragment petFragment on Pet { name ... on Dog { barkVolume}} "
+             "fragment catOrDogFragment on CatOrDog { ... on Cat { meowVolume }}"),
+    false = th:v(
+              "{ human { ...humanOrAlienFragment }} "
+              "fragment sentientFragment on Sentient {... on Dog {barkVolume}} "
+              "fragment humanOrAlienFragment on HumanOrAlien {... on Cat {meowVolume}}"),
     ok.
 
 v_5_5_1(_Config) ->


### PR DESCRIPTION
If we do this validation correctly, 4 other issues are solved right away. This PR tracks the implementation.

Preliminary plan:

- [x] Thread the current contextual scope around in the GraphQL type checker.
- [x] Write a judgment which can figure out if a given spread is allowed in a given scope, depending on the schemas and types.
- [x] Use the judgment in the correct places to verify the scoping rules.
- [x] Implement test cases from the spec, closing the corresponding issues in the process.
