### PR TITLE
Pass on null values rather than errors. Closes #128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the compatibility issues you are likely to encounter.
   values. Suppose we have a `DOG` of type `Pet`. Then, coercion of a
   value `DOG` into a context `[Pet]` is now regarded as having
   supplied `[DOG]`.
+- Sometimes, errors were not leading to `null` values, but were
+  propagated to the parent objects. This has now been fixed such that
+  errors occurs on the innermost object that can be nullable as per
+  the specification.
 
 ### Changed
 - Format type values as binary() in error's messages

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -499,9 +499,7 @@ complete_value(Path, _Ctx, #enum_type { id = ID,
                     null(Path, {invalid_enum_output, ID, Result}, Errors);
                 not_found ->
                     null(Path, {invalid_enum_output, ID, Result}, Errors)
-            end;
-        {error, Reasons} ->
-            {error, Reasons}
+            end
     end;
 complete_value(Path, Ctx, #interface_type{ resolve_type = Resolver }, Fields, {ok, Value}) ->
     complete_value_abstract(Path, Ctx, Resolver, Fields, {ok, Value});

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -758,7 +758,7 @@ invalid_type_resolution(Config) ->
     Input = #{
       <<"id">> => base64:encode(<<"kraken:1">>)
      },
-    #{ data := null,
+    #{ data := #{ <<"thing">> := null },
        errors :=
            [#{ path := [<<"LookupThing">>, <<"thing">>],
                key := {type_resolver_error, kraken},


### PR DESCRIPTION
This solves a number of mistakes in the code base w.r.t error
handling. Rather than completing nulls at the top-level too much,
complete nulls at the point where the error occurs.