### PR TITLE
Address the problem of annotating enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ the compatibility issues you are likely to encounter.
 
 ## [Unreleased]
 
+### Added
+- You can now annotate enum values with descriptions
+
 ### Fixed
 - Heed Oct2016 spec section 3.1.7 w.r.t input coercion of scalar
   values. Suppose we have a `DOG` of type `Pet`. Then, coercion of a

--- a/src/graphql_internal.hrl
+++ b/src/graphql_internal.hrl
@@ -126,10 +126,15 @@
           annotations = [] :: any()
         }).
 
+-record(p_enum_value,
+        { id :: name(),
+          annotations = [] :: any() }).
+-type p_enum_value() :: #p_enum_value{}.
+
 -record(p_enum,
         { id :: name(),
           annotations = [] :: any(),
-          variants = [] :: any()
+          variants = [] :: [p_enum_value()]
         }).
 
 -record(p_input_object,

--- a/src/graphql_internal.hrl
+++ b/src/graphql_internal.hrl
@@ -127,7 +127,7 @@
         }).
 
 -record(p_enum_value,
-        { id :: name(),
+        { id :: binary(),
           annotations = [] :: any() }).
 -type p_enum_value() :: #p_enum_value{}.
 

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -412,7 +412,11 @@ EnumTypeDefinition -> 'enum' Name '{' EnumValueDefinitionList '}' :
 EnumValueDefinitionList -> EnumValueDefinition : ['$1'].
 EnumValueDefinitionList -> EnumValueDefinition EnumValueDefinitionList : ['$1'|'$2'].
 
-EnumValueDefinition -> EnumValue : '$1'.
+EnumValueDefinition -> EnumValue :
+    #p_enum_value { id = '$1' }.
+EnumValueDefinition -> AnnotationList EnumValue :
+    #p_enum_value { id = '$2',
+                    annotations = '$1' }.
 
 InputObjectTypeDefinition -> AnnotationList 'input' Name '{' InputValueDefinitionList '}' :
                                  #p_input_object{

--- a/src/graphql_schema_parse.erl
+++ b/src/graphql_schema_parse.erl
@@ -53,8 +53,8 @@ mk(#{ objects := OM }, #p_type {
        resolve_module => Mod,
        interfaces => Implements }};
 mk(#{ enums := En }, #p_enum { id = ID,
-			       annotations = Annots,
-			       variants = Vs }) ->
+                               annotations = Annots,
+                               variants = Vs }) ->
     Name = name(ID),
     Description = description(Annots),
     Variants = variants(Vs),
@@ -181,9 +181,13 @@ find(T, [#annotation { id = {name, _, T}} = A|_]) -> A;
 find(T, [#annotation{}|Next]) -> find(T, Next).
 
 variants(Vs) ->
-    F = fun(V, I) ->
+    F = fun(#p_enum_value { id = V,
+                            annotations = Annots }, I) ->
                 K = binary_to_atom(V, utf8),
-                {K, #{ value => I, description => "No descriptions supported yet" }}
+                Description = description(Annots),
+                {K, #{ value => I,
+                       annotations => annotations(Annots),
+                       description => Description }}
         end,
     maps:from_list(mapi(F, Vs)).
 

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -2,8 +2,11 @@ scalar ColorType
 scalar Color
 
 enum Mood {
+     +description(text: "A very calm monster")
      TRANQUIL
+     +description(text: "A monster trying to avoid you")
      DODGY
+     +description(text: "This monster attacks every living being, including itself")
      AGGRESSIVE
 }
 


### PR DESCRIPTION
This patch should fix the problem that you cannot attach descriptions to enum values in the schema parser.