### PR TITLE
Fix: correct ordering of type checking

### DIFF
--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -576,18 +576,6 @@ judge_list(Ctx, Path, [V|Vs], Type, K) ->
 %% from the document first and then make the inversion analysis on the schema-type.
 judge(Ctx, Path, {name, _, N}, SType) ->
     judge(Ctx, Path, N, SType);
-judge(Ctx, Path, Value, {non_null, InnerSType} = SType) ->
-    case Value of
-        null ->
-            err(Path, {type_mismatch,
-                       #{ document => Value, schema => SType }});
-        _Valid ->
-            judge(Ctx, Path, Value, InnerSType)
-    end;
-judge(_Ctx, _Path, null, _SType) ->
-    %% If a value is null, and we don't have a non-null case,
-    %% then the value is valid
-    null;
 judge(#{ varenv := VE }, Path, {var, ID}, SType) ->
     Var = graphql_ast:name(ID),
     case maps:get(Var, VE, not_found) of
@@ -602,6 +590,18 @@ judge(#{ varenv := VE }, Path, {var, ID}, SType) ->
                                   schema => SType }})
             end
     end;
+judge(Ctx, Path, Value, {non_null, InnerSType} = SType) ->
+    case Value of
+        null ->
+            err(Path, {type_mismatch,
+                       #{ document => Value, schema => SType }});
+        _Valid ->
+            judge(Ctx, Path, Value, InnerSType)
+    end;
+judge(_Ctx, _Path, null, _SType) ->
+    %% If a value is null, and we don't have a non-null case,
+    %% then the value is valid
+    null;
 judge(Ctx, Path, Values, SType) when is_list(Values) ->
     case SType of
         {list, InnerType} ->

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -326,6 +326,6 @@ v_5_7_3(_Config) ->
     false = th:v("query Q($var : Pet) { dog { name } }"),
     false = th:v("query Q($var : Dog) { dog { name } }"),
     true  = th:v(
-        "query Q($command : DogCommand) {"
+        "query Q($command : DogCommand!) {"
         " dog { doesKnowCommand(dogCommand : $command) } }"),
     ok.

--- a/test/validation_SUITE.erl
+++ b/test/validation_SUITE.erl
@@ -328,4 +328,8 @@ v_5_7_3(_Config) ->
     true  = th:v(
         "query Q($command : DogCommand!) {"
         " dog { doesKnowCommand(dogCommand : $command) } }"),
+    false  = th:v(
+        "query Q($command : DogCommand) {"
+        " dog { doesKnowCommand(dogCommand : $command) } }"),
+
     ok.


### PR DESCRIPTION
The type checkers main judgment order is wrong. This means you don't get an appropriate warning when you supply a nullable input in a non-null context.