### PR TITLE
Remove the schema lookup from the YRL grammar

### DIFF
--- a/src/graphql_elaborate.erl
+++ b/src/graphql_elaborate.erl
@@ -62,6 +62,9 @@ type({list, Ty}) ->
         {error, Reason} -> {error, Reason};
         {Polarity, V} -> {Polarity, {list, V}}
     end;
+type({scalar, Name}) ->
+    #scalar_type{} = Ty = graphql_schema:get(Name),
+    {_polarity, Ty} = type(Ty);
 type(#scalar_type{} = Ty) -> {'*', Ty};
 type({enum, _} = E) -> {'*', E};
 type(#enum_type{} = Ty) -> {'*', Ty};

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -441,19 +441,19 @@ g_query({query, _L} = Q) -> Q.
 g_mutation({mutation, _L} = Mut) -> Mut.
 g_subscription({subscription, _L} = Sub) -> Sub.
 
-g_ty({name, _, <<"String">>}) -> scalar_lookup(<<"String">>);
-g_ty({name, _, <<"string">>}) -> scalar_lookup(<<"String">>);
-g_ty({name, _, <<"Int">>}) -> scalar_lookup(<<"Int">>);
-g_ty({name, _, <<"int">>}) -> scalar_lookup(<<"Int">>);
-g_ty({name, _, <<"float">>}) -> scalar_lookup(<<"Float">>);
-g_ty({name, _, <<"Float">>}) -> scalar_lookup(<<"Float">>);
-g_ty({name, _, <<"bool">>}) -> scalar_lookup(<<"Bool">>);
-g_ty({name, _, <<"Bool">>}) -> scalar_lookup(<<"Bool">>);
-g_ty({name, _, <<"boolean">>}) -> scalar_lookup(<<"Bool">>);
-g_ty({name, _, <<"Boolean">>}) -> scalar_lookup(<<"Bool">>);
-g_ty({name, _, <<"id">>}) -> scalar_lookup(<<"ID">>);
-g_ty({name, _, <<"Id">>}) -> scalar_lookup(<<"ID">>);
-g_ty({name, _, <<"ID">>}) -> scalar_lookup(<<"ID">>);
+g_ty({name, _, <<"String">>}) -> wrap_scalar(<<"String">>);
+g_ty({name, _, <<"string">>}) -> wrap_scalar(<<"String">>);
+g_ty({name, _, <<"Int">>}) -> wrap_scalar(<<"Int">>);
+g_ty({name, _, <<"int">>}) -> wrap_scalar(<<"Int">>);
+g_ty({name, _, <<"float">>}) -> wrap_scalar(<<"Float">>);
+g_ty({name, _, <<"Float">>}) -> wrap_scalar(<<"Float">>);
+g_ty({name, _, <<"bool">>}) -> wrap_scalar(<<"Bool">>);
+g_ty({name, _, <<"Bool">>}) -> wrap_scalar(<<"Bool">>);
+g_ty({name, _, <<"boolean">>}) -> wrap_scalar(<<"Bool">>);
+g_ty({name, _, <<"Boolean">>}) -> wrap_scalar(<<"Bool">>);
+g_ty({name, _, <<"id">>}) -> wrap_scalar(<<"ID">>);
+g_ty({name, _, <<"Id">>}) -> wrap_scalar(<<"ID">>);
+g_ty({name, _, <<"ID">>}) -> wrap_scalar(<<"ID">>);
 g_ty({name, _, _} = N) -> N.
 
 g_enum({name, _Line, N}) -> N.
@@ -472,6 +472,5 @@ g_input_object(KVPairs) ->
 keyword({A, Line}) when is_atom(A) ->
     {name, Line, atom_to_binary(A, utf8)}.
 
-scalar_lookup(Name) ->
-  #scalar_type{} = Ty = graphql_schema:get(Name),
-  Ty.
+wrap_scalar(Name) ->
+    {scalar, Name}.

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -441,19 +441,19 @@ g_query({query, _L} = Q) -> Q.
 g_mutation({mutation, _L} = Mut) -> Mut.
 g_subscription({subscription, _L} = Sub) -> Sub.
 
-g_ty({name, _, <<"String">>}) -> wrap_scalar(<<"String">>);
-g_ty({name, _, <<"string">>}) -> wrap_scalar(<<"String">>);
-g_ty({name, _, <<"Int">>}) -> wrap_scalar(<<"Int">>);
-g_ty({name, _, <<"int">>}) -> wrap_scalar(<<"Int">>);
-g_ty({name, _, <<"float">>}) -> wrap_scalar(<<"Float">>);
-g_ty({name, _, <<"Float">>}) -> wrap_scalar(<<"Float">>);
-g_ty({name, _, <<"bool">>}) -> wrap_scalar(<<"Bool">>);
-g_ty({name, _, <<"Bool">>}) -> wrap_scalar(<<"Bool">>);
-g_ty({name, _, <<"boolean">>}) -> wrap_scalar(<<"Bool">>);
-g_ty({name, _, <<"Boolean">>}) -> wrap_scalar(<<"Bool">>);
-g_ty({name, _, <<"id">>}) -> wrap_scalar(<<"ID">>);
-g_ty({name, _, <<"Id">>}) -> wrap_scalar(<<"ID">>);
-g_ty({name, _, <<"ID">>}) -> wrap_scalar(<<"ID">>);
+g_ty({name, _, <<"String">>}) -> {scalar, <<"String">>};
+g_ty({name, _, <<"string">>}) -> {scalar, <<"String">>};
+g_ty({name, _, <<"Int">>}) -> {scalar, <<"Int">>};
+g_ty({name, _, <<"int">>}) -> {scalar, <<"Int">>};
+g_ty({name, _, <<"float">>}) -> {scalar, <<"Float">>};
+g_ty({name, _, <<"Float">>}) -> {scalar, <<"Float">>};
+g_ty({name, _, <<"bool">>}) -> {scalar, <<"Bool">>};
+g_ty({name, _, <<"Bool">>}) -> {scalar, <<"Bool">>};
+g_ty({name, _, <<"boolean">>}) -> {scalar, <<"Bool">>};
+g_ty({name, _, <<"Boolean">>}) -> {scalar, <<"Bool">>};
+g_ty({name, _, <<"id">>}) -> {scalar, <<"ID">>};
+g_ty({name, _, <<"Id">>}) -> {scalar, <<"ID">>};
+g_ty({name, _, <<"ID">>}) -> {scalar, <<"ID">>};
 g_ty({name, _, _} = N) -> N.
 
 g_enum({name, _Line, N}) -> N.
@@ -471,6 +471,3 @@ g_input_object(KVPairs) ->
 %% Convert keywords into binaries if they don't occur in the KW-position
 keyword({A, Line}) when is_atom(A) ->
     {name, Line, atom_to_binary(A, utf8)}.
-
-wrap_scalar(Name) ->
-    {scalar, Name}.

--- a/src/graphql_schema_parse.erl
+++ b/src/graphql_schema_parse.erl
@@ -199,6 +199,9 @@ mapi(F,  [X|Xs], K) -> [F(X, K) | mapi(F, Xs, K+1)].
 handle_type({non_null, T}) -> {non_null, handle_type(T)};
 handle_type({list, T}) -> {list, handle_type(T)};
 handle_type({name, _, T}) -> binary_to_atom(T, utf8);
+handle_type({scalar, Name}) ->
+    #scalar_type{} = Ty = graphql_schema:get(Name),
+    handle_type(Ty);
 handle_type(#scalar_type{ id = Id }) -> binary_to_atom(Id, utf8).
 
 mapping(Name, Map) ->


### PR DESCRIPTION
Instead of performing a schema lookup in the YRL grammar when encountering a scalar value we will replace it with a `{scalar, Name}` and perform the lookup in the parser and elaborator.

I don't know if I've done this correctly. The note about the suggested fix stated that I should only perform the lookup in the `graphql_elaborate`-module, but I had to handle the scalar-type in `graphql_schema_parse` as well it seems.

The test suite still passes when these changes are applied.

This PR is part of solving issue #91