### PR TITLE
Format string error for Operation value

### DIFF
--- a/src/graphql_type_check.erl
+++ b/src/graphql_type_check.erl
@@ -668,7 +668,7 @@ err(Path, Msg) ->
 err_msg(unnamed_operation_params) ->
     ["Cannot supply parameter lists to unnamed (anonymous) queries"];
 err_msg({operation_not_found, Op}) ->
-    ["Expected an operation ", Op, " but no such operation was found"];
+    io_lib:format("Expected an operation ~p but no such operation was found", [Op]);
 err_msg(missing_non_null_param) ->
     ["The parameter is non-null, but was undefined in parameter list"];
 err_msg(non_null) ->


### PR DESCRIPTION
This format change solve this format error when the op es is not a string, for example `null` or another atom().
```erlang
{[{reason,badarg},{mfa,{server_cowboy_handler,from_json,2}},{stacktrace,[{erlang,iolist_to_binary,[["Expected an operation ",null," but no such operation was found"]],[]},{graphql_err,mk,3,[{file,"/build/jenkins/workspace/server/_build/default/lib/graphql/src/graphql_err.erl"},{line,22}]},{graphql_err,abort,3,[{file,"/build/jenkins/workspace/server/_build/default/lib/graphql/src/graphql_err.erl"},{line,16}]},{server_cowboy_handler,run,5,[{file,"/build/jenkins/workspace/server/_build/prod/lib/server_http/src/server_cowboy_handler.erl"},{line,174}]},{cowboy_rest,call,3,[{file,"/build/jenkins/workspace/server/_build/default/lib/cowboy/src/cowboy_rest.erl"},{line,976}]},{cowboy_rest,process_content_type,3,[{file,"/build/jenkins/workspace/server/_build/default/lib/cowboy/src/cowboy_rest.erl"},{line,777}]},{cowboy_protocol,execute,4,[{file,"/build/jenkins/workspace/server/_build/default/lib/cowboy/src/cowboy_protocol.erl"},{line,442}]}]},{req,[{socket,#Port<0.242877>},{transport,ranch_tcp}

```
