### PR TITLE
use utf8 description strings in src/graphql_builtins.erl

### DIFF
--- a/src/graphql_builtins.erl
+++ b/src/graphql_builtins.erl
@@ -9,19 +9,19 @@
 standard_types_inject() ->
     String = {scalar, #{
     	id => 'String',
-    	description => "UTF-8 Text Strings" }},
+    	description => <<"UTF-8 Text Strings"/utf8>> }},
     Float = {scalar, #{
     	id => 'Float',
-    	description => "Floating point values, IEEE 754, but not ±infty, nor NaN" }},
+    	description => <<"Floating point values, IEEE 754, but not infinity, nor NaN"/utf8>> }},
     Int = {scalar, #{
     	id => 'Int',
-    	description => "Integers in the range ±2^53. The GraphQL standard only allows for 32-bit signed integers, but we can support up to the larger range." }},
+    	description => <<"Integers in the range ±2^53. The GraphQL standard only allows for 32-bit signed integers, but we can support up to the larger range."/utf8>> }},
     Bool = {scalar, #{
     	id => 'Bool',
-    	description => "Boolean values, either given as the *true* and *false* values of JSON, or as the strings \"true\" and \"false\"." }},
+    	description => <<"Boolean values, either given as the *true* and *false* values of JSON, or as the strings \"true\" and \"false\"."/utf8>> }},
     ID = {scalar, #{
     	id => 'ID',
-    	description => "Representation of an opaque ID in the system. Always returned/given as strings, but clients are not allowed to deconstruct them. The server might change them as it sees fit later on, and the clients must be able to handle this situation." }},
+    	description => <<"Representation of an opaque ID in the system. Always returned/given as strings, but clients are not allowed to deconstruct them. The server might change them as it sees fit later on, and the clients must be able to handle this situation."/utf8>> }},
     ok = graphql:insert_schema_definition(String),
     ok = graphql:insert_schema_definition(Float),
     ok = graphql:insert_schema_definition(Int),


### PR DESCRIPTION
* prevents encoding issues mentioned in #136 