### PR TITLE
Handle undefined operations. Closes #142.

### DIFF
--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -44,6 +44,7 @@ path(Path) ->
            F('ROOT') -> <<"ROOT">>;
            F('...') -> <<"...">>;
            F(document) -> <<"document">>;
+           F(undefined) -> <<"..">>;
            F(#frag { id = ID }) -> name(ID);
            F(#op { id = ID }) -> name(ID);
            F(#field { id = ID }) -> name(ID);


### PR DESCRIPTION
It is possible to hit a path component 'undefined' in the case where
no operation is given. This then leads to a path resolver error which
then fails to produce a correct error message.