### PR TITLE
Jl/union query

### DIFF
--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -237,6 +237,10 @@ unions(Config) ->
 
     Expected4 = #{ data => #{ <<"things">> => [#{ <<"__typename">> => <<"Monster">>, <<"name">> => <<"goblin">> }]}},
     Expected4 = run(Config, <<"ThingQ2">>, #{ }),
+
+    Expected5 = #{ data => #{ <<"things">> => [#{ <<"__typename">> => <<"Monster">> }]}},
+    Expected5 = run(Config, <<"ThingQ3">>, #{ }),
+
     ok.
 
 union_errors(Config) ->

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -231,6 +231,12 @@ unions(Config) ->
                          <<"name">> => <<"goblin">>,
                          <<"hitpoints">> => 10 }}},
     Expected2 = run(Config, <<"GoblinThingQuery">>, #{ <<"id">> => OpaqueId }),
+    ct:log("Union expansions"),
+    Expected3 = #{ data => #{ <<"things">> => [#{}]}},
+    Expected3 = run(Config, <<"ThingQ1">>, #{ }),
+
+    Expected4 = #{ data => #{ <<"things">> => [#{ <<"__typename">> => <<"Monster">>, <<"name">> => <<"goblin">> }]}},
+    Expected4 = run(Config, <<"ThingQ2">>, #{ }),
     ok.
 
 union_errors(Config) ->

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -152,6 +152,7 @@ type QueryRoot {
   monsters(ids: [ID!]) : [Monster]
   findMonsters(moods: [Mood]) : [Monster]
   thing(id: ID!) : Thing
+  things(ids: [ID!]) : [Thing]
   room(id: ID!) : Room
   rooms(ids: [ID!]) : [Room!]
   roll(delay: Int) : Dice

--- a/test/dungeon_SUITE_data/query.graphql
+++ b/test/dungeon_SUITE_data/query.graphql
@@ -40,7 +40,13 @@ query ThingQ2 {
     }
   }
 }
-  
+
+query ThingQ3 {
+  things(ids: ["bW9uc3Rlcjox"]) {
+    __typename
+  }
+}
+
 query InvalidEnumOutput($id : Id! =  "bW9uc3Rlcjox") {
   goblin: monster(id: $id) {
     id

--- a/test/dungeon_SUITE_data/query.graphql
+++ b/test/dungeon_SUITE_data/query.graphql
@@ -24,6 +24,23 @@ query FindQuery {
   }
 }
 
+query ThingQ1 {
+  things(ids: ["bW9uc3Rlcjox"]) {
+    ... on Item {
+      __typename
+    }
+  }
+}
+
+query ThingQ2 {
+  things(ids: ["bW9uc3Rlcjox"]) {
+    ... on Monster {
+      __typename
+      name
+    }
+  }
+}
+  
 query InvalidEnumOutput($id : Id! =  "bW9uc3Rlcjox") {
   goblin: monster(id: $id) {
     id

--- a/test/dungeon_query.erl
+++ b/test/dungeon_query.erl
@@ -27,6 +27,12 @@ execute(_Ctx, _, <<"thing">>, #{ <<"id">> := InputID }) ->
         {item, _ID} = OID -> dungeon:dirty_load(OID);
         {kraken, _ID} = _OID -> {ok, kraken}
     end;
+execute(_Ctx, _, <<"things">>, #{ <<"ids">> := Inputs }) ->
+    {ok, [case dungeon:unwrap(I) of
+              {monster, _ID} = OID -> dungeon:dirty_load(OID);
+              {item, _ID} = OID -> dungeon:dirty_load(OID);
+              {kraken, _ID} = _OID -> {ok, kraken}
+          end || I <- Inputs]};
 execute(_Ctx, _, <<"room">>, #{ <<"id">> := InputID }) ->
     case dungeon:unwrap(InputID) of
         {room, _ID} = OID -> dungeon:dirty_load(OID)


### PR DESCRIPTION
In order to verify that lists of unions are handled as expected, we add some tests to the `unions` test case to make sure that things expand like they should. We can use this test case to track if the system operates in a way that is correct according to the specification.