### PR TITLE
This is a failing test case covering an introspection query erro when using a variable in fragment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dialyzer:
 	@$(REBAR) dialyzer
 
 test:
-	@$(REBAR) ct
+	@$(REBAR) ct --spec test/test.spec
 
 test-cover:
 	@$(REBAR) do ct -c, cover -v

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -75,6 +75,7 @@ groups() ->
          , multiple_monsters_and_rooms
          , include_directive
          , introspection
+         , introspection_with_variable
          , get_operation
          , coercion_int_float
          , replace_enum_representation
@@ -132,6 +133,19 @@ introspection(Config) ->
     case run(Config,
              <<"introspection.graphql">>,
              <<"IntrospectionQuery">>, #{}) of
+        #{ errors := [] } ->
+            ok;
+        #{ errors := Errs } ->
+            ct:log("Errors: ~p", [Errs]),
+            ct:fail(introspection_errors);
+        #{ } ->
+            ok %% No Errors present, so this is OK
+    end.
+
+introspection_with_variable(Config) ->
+    case run(Config,
+             <<"introspection_with_variable.graphql">>,
+             <<"IntrospectionQuery">>, #{<<"includeDeprecated">> => false}) of
         #{ errors := [] } ->
             ok;
         #{ errors := Errs } ->

--- a/test/dungeon_SUITE_data/introspection_with_variable.graphql
+++ b/test/dungeon_SUITE_data/introspection_with_variable.graphql
@@ -1,0 +1,14 @@
+query IntrospectionQuery($includeDeprecated: Boolean!) {
+    __schema {
+          types {
+                  ...FullType
+                      }
+                        }
+}
+
+fragment FullType on __Type {
+    fields(includeDeprecated: $includeDeprecated) {
+          name
+            }
+}
+

--- a/test/test.spec
+++ b/test/test.spec
@@ -1,0 +1,2 @@
+{suites, ".", all}.
+{skip_cases, ".", dungeon_SUITE, introspection_with_variable, "This test is waiting for #107 to be fixed"}.


### PR DESCRIPTION
This PR is a **failing test** case, (_no fix included_) that demonstrates an error I came across when sending an introspection query using a variable and using that variable in a fragment.

The background is that I was trying out an [Elm GraphQl package](http://package.elm-lang.org/packages/dillonkearns/graphqelm/latest) together with your [tutorial server](https://shopgun.github.io/graphql-erlang-tutorial/) and getting this error:

```
$ graphqelm http://localhost:17290
{ errors: 
   [ { message: '{error,#{key =>\n            {input_coercion,<<"Bool">>,\n                             {var,{name,19,<<"includeDeprecated">>}},\n                             not_bool},\n         message =>\n             <<"General uncategorized error: {input_coercion,<<\\"Bool\\">>,\\n                                 {var,{name,19,<<\\"includeDeprecated\\">>}},\\n                                 not_bool}">>,\n         path => [<<"document">>,<<"fields">>,<<"includeDeprecated">>]}}',
       type: 'error' } ],
  status: 400 }
```
The test data file in this PR includes a cut down version of the query that still exhibits the error. 
As far as I have been able to tell it is provoked when using a query variable in an introspection query, and then using this query variable in a fragment. If I try to use the query variable directly in the query part it is ok, and if I use a hard coded parameter in the fragment part it is ok. From the error message it seems that the graphql engine tries to pass the AST of the variable (or variable listed in the fragment?) to the graphql_scalar_bool_coerce.erl functions, instead of the resolved value?