### PR TITLE
Make the null value customizable [wip]

### DIFF
--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -99,7 +99,7 @@ elaborate(AST) ->
 
 -spec type_check_params(any(), any(), any()) -> param_context().
 type_check_params(FunEnv, OpName, Vars) ->
-    graphql_type_check:x_params(#{}, FunEnv, OpName, Vars).
+    graphql_type_check:x_params(#{null_value => owl}, FunEnv, OpName, Vars).
 
 -spec type_check_params(map(), any(), any(), any()) -> param_context().
 type_check_params(Ctx, FunEnv, OpName, Vars) ->

--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -6,7 +6,7 @@
 -export([
          parse/1,
          elaborate/1,
-         type_check/1, type_check_params/3,
+         type_check/1, type_check_params/3, type_check_params/4,
          validate/1,
          execute/1, execute/2
         ]).
@@ -99,7 +99,12 @@ elaborate(AST) ->
 
 -spec type_check_params(any(), any(), any()) -> param_context().
 type_check_params(FunEnv, OpName, Vars) ->
-    graphql_type_check:x_params(FunEnv, OpName, Vars).
+    graphql_type_check:x_params(#{}, FunEnv, OpName, Vars).
+
+-spec type_check_params(map(), any(), any(), any()) -> param_context().
+type_check_params(Ctx, FunEnv, OpName, Vars) ->
+    graphql_type_check:x_params(Ctx, FunEnv, OpName, Vars).
+
 
 -spec execute(ast()) -> #{ atom() => json() }.
 execute(AST) ->
@@ -123,4 +128,3 @@ insert_schema_definition(Defn) ->
 -spec validate_schema() -> ok | {error, any()}.
 validate_schema() ->
     graphql_schema_validate:x().
-

--- a/src/graphql_enum_coerce.erl
+++ b/src/graphql_enum_coerce.erl
@@ -7,4 +7,3 @@ input(_, _) -> {error, not_valid_enum_input}.
 
 output(_, {enum, X}) -> {ok, X};
 output(_, Str) when is_binary(Str) -> {ok, Str}.
-

--- a/src/graphql_scalar_binary_coerce.erl
+++ b/src/graphql_scalar_binary_coerce.erl
@@ -5,4 +5,4 @@
 input(_, X) -> {ok, X}.
 
 output(_,B) when is_binary(B) -> {ok, B};
-output(_,_)                   -> {ok, null}.
+output(_,_) -> {ok, owl}.

--- a/src/graphql_scalar_bool_coerce.erl
+++ b/src/graphql_scalar_bool_coerce.erl
@@ -10,4 +10,4 @@ output(<<"Bool">>, true)        -> {ok, true};
 output(<<"Bool">>, <<"true">>)  -> {ok, true};
 output(<<"Bool">>, false)       -> {ok, false};
 output(<<"Bool">>, <<"false">>) -> {ok, false};
-output(_,_)                     -> {ok, null}.
+output(_,_)                     -> {ok, owl}.

--- a/src/graphql_scalar_float_coerce.erl
+++ b/src/graphql_scalar_float_coerce.erl
@@ -7,4 +7,4 @@ input(_, X) ->
 
 output(<<"Float">>, F) when is_float(F)  -> {ok, F};
 output(<<"Float">>,I) when is_integer(I) -> {ok, float(I)};
-output(_,_)                              -> {ok, null}.
+output(_,_)                              -> {ok, owl}.

--- a/src/graphql_scalar_integer_coerce.erl
+++ b/src/graphql_scalar_integer_coerce.erl
@@ -6,4 +6,4 @@ input(_, X) ->
     {ok, X}.
 
 output(<<"Int">>, I) when is_integer(I) -> {ok, I};
-output(_,_)                             -> {ok, null}.
+output(_,_)                             -> {ok, owl}.

--- a/src/graphql_schema_canonicalize.erl
+++ b/src/graphql_schema_canonicalize.erl
@@ -30,10 +30,10 @@ x({union, #{ id := ID, description := Desc, types := Types } = U}) ->
 x({enum, #{ id := ID, description := Desc, values := VDefs} = Enum}) ->
     ModuleResolver = enum_resolve(Enum),
     #enum_type {
-    	id = c_id(ID),
-    	description = binarize(Desc),
-    	annotations = annotations(Enum),
-    	values = map_2(fun c_enum_val/2, VDefs),
+        id = c_id(ID),
+        description = binarize(Desc),
+        annotations = annotations(Enum),
+        values = map_2(fun c_enum_val/2, VDefs),
         resolve_module = ModuleResolver
      };
 
@@ -111,12 +111,12 @@ c_field(K, V) ->
 
 c_field_val(M) ->
     #schema_field {
-    	ty = c_field_val_ty(M),
-    	resolve = c_field_val_resolve(M),
-    	args = c_field_val_args(M),
-    	deprecation = deprecation(M),
-    	annotations = annotations(M),
-    	description = c_field_val_description(M)
+        ty = c_field_val_ty(M),
+        resolve = c_field_val_resolve(M),
+        args = c_field_val_args(M),
+        deprecation = deprecation(M),
+        annotations = annotations(M),
+        description = c_field_val_description(M)
     }.
 
 c_field_val_ty(#{ type := Ty }) ->

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -159,7 +159,7 @@ invalid_list_resolver(Config) ->
     GoblinId = ?config(known_goblin_id_1, Config),
     Q1 = "query Q { monster(id: \"" ++ binary_to_list(GoblinId) ++ "\") { errorListResolution }} ",
     Expected =
-        #{data => #{<<"monster">> => #{<<"errorListResolution">> => null}},
+        #{data => #{<<"monster">> => #{<<"errorListResolution">> => owl}},
           errors =>
               [#{key => list_resolution,
                  message =>
@@ -280,7 +280,7 @@ invalid_enum_result(Config) ->
     #{ data := #{
          <<"goblin">> := #{
            <<"id">> := <<"bW9uc3Rlcjox">>,
-           <<"mood">> := null }}} =
+           <<"mood">> := owl }}} =
         run(Config, <<"InvalidEnumOutput">>, #{}),
     ok.
 
@@ -394,7 +394,7 @@ direct_input(Config) ->
     },
     #{ data := #{
         <<"introduceMonster">> := #{
-            <<"clientMutationId">> := null,
+            <<"clientMutationId">> := owl,
             <<"monster">> := #{
                 <<"id">> := _,
                 <<"name">> := <<"Albino Hobgoblin">>,
@@ -402,7 +402,7 @@ direct_input(Config) ->
                 <<"hitpoints">> := 5,
                 <<"properties">> := [<<"DRAGON">>, <<"MURLOC">>],
                 <<"mood">> := <<"AGGRESSIVE">>,
-                <<"stats">> := null}
+                <<"stats">> := owl}
         }}} = run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input}),
     ok.
 
@@ -418,7 +418,7 @@ fixed_input(Config) ->
                 <<"plushFactor">> := 0.01,
                 <<"properties">> := [],
                 <<"mood">> := <<"DODGY">>,
-               <<"stats">> := null}
+               <<"stats">> := owl}
         }}} = run(Config, <<"IntroduceMonsterFatFixedInput">>, #{ }),
     ok.
 
@@ -509,7 +509,7 @@ complex_modifiers(Config) ->
     #{ data :=
         #{ <<"monster">> := #{
             <<"stats">> := [
-                null,
+                owl,
                 #{
                   <<"attack">> := 7,
                   <<"shellScripting">> := 17,
@@ -520,7 +520,7 @@ complex_modifiers(Config) ->
     #{ data :=
           #{ <<"monster">> := #{
             <<"statsVariantOne">> := [
-                null,
+                owl,
                 #{
                   <<"attack">> := 7,
                   <<"shellScripting">> := 17,
@@ -530,12 +530,12 @@ complex_modifiers(Config) ->
     %% list becomes null, and this is a valid value. So return the list itself as the value 'null'
     #{ data :=
         #{ <<"monster">> := #{
-            <<"statsVariantTwo">> := null  }}} =
+            <<"statsVariantTwo">> := owl  }}} =
             run(Config, <<"MonsterStatsTwo">>, #{ <<"id">> => MonsterID }),
 
     %% If the list may not be null, make sure the error propagates to the wrapper object.
     #{ data :=
-        #{ <<"monster">> := null },
+        #{ <<"monster">> := owl },
         errors := [#{path :=
                          [<<"MonsterStatsThree">>, <<"monster">>, <<"statsVariantThree">>],
                      key := null_value,
@@ -573,7 +573,7 @@ non_null_field(Config) ->
                                                            <<"name">> := <<"Brown Slime">>,
                                                            <<"id">> := _,
                                                            <<"plushFactor">> := PF,
-                                                           <<"stats">> := [null] }}}} =
+                                                           <<"stats">> := [owl] }}}} =
              run(Config, <<"IntroduceMonsterFat">>, #{ <<"input">> => Input}),
     true = (PF - 1.0) < 0.00001,
     ok.
@@ -615,7 +615,7 @@ multiple_monsters_and_rooms(Config) ->
 
     #{ data := #{
         <<"monsters">> := [
-            #{ <<"id">> := ID1 }, #{ <<"id">> := ID2 } , null ]},
+            #{ <<"id">> := ID1 }, #{ <<"id">> := ID2 } , owl ]},
        errors := [
            #{path := [<<"MultipleMonsters">>, <<"monsters">>, 2],
              message := <<"not_found">> }]
@@ -623,7 +623,7 @@ multiple_monsters_and_rooms(Config) ->
 
     #{ data := #{
         <<"monsters">> := [
-            #{ <<"id">> := ID1 }, null, #{ <<"id">> := ID2 }, null ]},
+            #{ <<"id">> := ID1 }, owl, #{ <<"id">> := ID2 }, owl ]},
        errors := [
                   #{path := [<<"MultipleMonstersExprMissing">>, <<"monsters">>, 1],
                     message := <<"not_found">>},
@@ -637,7 +637,7 @@ multiple_monsters_and_rooms(Config) ->
          <<"rooms">> := [#{<<"id">> := Room1}]}
      } = run(Config, <<"MultipleRooms">>, #{ <<"ids">> => [Room1]}),
     % look for an existing room and a non existing room
-    #{ data := #{ <<"rooms">> := null },
+    #{ data := #{ <<"rooms">> := owl },
        errors :=
            [#{path := [<<"MultipleRooms">>, <<"rooms">>, 1],
               key := null_value },
@@ -817,7 +817,7 @@ invalid_type_resolution(Config) ->
     Input = #{
       <<"id">> => base64:encode(<<"kraken:1">>)
      },
-    #{ data := #{ <<"thing">> := null },
+    #{ data := #{ <<"thing">> := owl },
        errors :=
            [#{ path := [<<"LookupThing">>, <<"thing">>],
                key := {type_resolver_error, kraken},

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -43,8 +43,10 @@ init_per_testcase(x, Config) ->
     dbg:p(all, c),
     dbg:tpl(graphql_execute, does_fragment_type_apply, '_', cx),
     Config;
+init_per_testcase(direct_input, Config) ->
+    Config;
 init_per_testcase(_Case, Config) ->
-    Config.
+    {skip, remove_noise}.
 
 end_per_testcase(x, _Config) ->
     dbg:stop_clear(),
@@ -418,7 +420,7 @@ fixed_input(Config) ->
                 <<"plushFactor">> := 0.01,
                 <<"properties">> := [],
                 <<"mood">> := <<"DODGY">>,
-               <<"stats">> := owl}
+                <<"stats">> := owl}
         }}} = run(Config, <<"IntroduceMonsterFatFixedInput">>, #{ }),
     ok.
 

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -43,10 +43,7 @@ init_per_testcase(x, Config) ->
     dbg:p(all, c),
     dbg:tpl(graphql_execute, does_fragment_type_apply, '_', cx),
     Config;
-init_per_testcase(direct_input, Config) ->
-    Config;
-init_per_testcase(_Case, Config) ->
-    {skip, remove_noise}.
+init_per_testcase(_Case, Config) -> Config.
 
 end_per_testcase(x, _Config) ->
     dbg:stop_clear(),
@@ -502,21 +499,20 @@ complex_modifiers(Config) ->
           <<"shellScripting">> => 17,
           <<"yell">> => <<"I'M NOT READY!">> } ]},
     #{ data :=
-                      #{<<"introduceMonster">> := #{
-                          <<"monster">> := #{
-                            <<"id">> := MonsterID } } } } =
-             run(Config, <<"IntroduceMonsterFat">>, #{ <<"input">> => Input}),
+           #{<<"introduceMonster">> := #{
+                 <<"monster">> := #{
+                     <<"id">> := MonsterID } } }
+     } = run(Config, <<"IntroduceMonsterFat">>, #{ <<"input">> => Input}),
 
     %% Standard Query
     #{ data :=
         #{ <<"monster">> := #{
             <<"stats">> := [
                 owl,
-                #{
-                  <<"attack">> := 7,
-                  <<"shellScripting">> := 17,
-                  <<"yell">> := <<"I'M NOT READY!">> } ]  }}} =
-            run(Config, <<"MonsterStatsZero">>, #{ <<"id">> => MonsterID }),
+                #{ <<"attack">> := 7,
+                   <<"shellScripting">> := 17,
+                   <<"yell">> := <<"I'M NOT READY!">> } ]  }}
+     } = run(Config, <<"MonsterStatsZero">>, #{ <<"id">> => MonsterID }),
     %% When the list is non-null, but there are the possibility of a null-value in the list
     %% and the list is correctly being rendered, then render the list as we expect.
     #{ data :=
@@ -567,16 +563,16 @@ non_null_field(Config) ->
         <<"shellScripting">> => 5,
         <<"yell">> => <<"...">> }]},
     #{ data :=
-                      #{<<"introduceMonster">> := #{<<"clientMutationId">> := <<"123">>,
-                                                    <<"monster">> :=
-                                                        #{ <<"color">> := <<"#B7411E">>,
-                                                           <<"hitpoints">> := 7001,
-                                                           <<"mood">> := <<"TRANQUIL">>,
-                                                           <<"name">> := <<"Brown Slime">>,
-                                                           <<"id">> := _,
-                                                           <<"plushFactor">> := PF,
-                                                           <<"stats">> := [owl] }}}} =
-             run(Config, <<"IntroduceMonsterFat">>, #{ <<"input">> => Input}),
+           #{<<"introduceMonster">> := #{<<"clientMutationId">> := <<"123">>,
+                                         <<"monster">> :=
+                                             #{ <<"color">> := <<"#B7411E">>,
+                                                <<"hitpoints">> := 7001,
+                                                <<"mood">> := <<"TRANQUIL">>,
+                                                <<"name">> := <<"Brown Slime">>,
+                                                <<"id">> := _,
+                                                <<"plushFactor">> := PF,
+                                                <<"stats">> := [owl] }}}
+     } = run(Config, <<"IntroduceMonsterFat">>, #{ <<"input">> => Input}),
     true = (PF - 1.0) < 0.00001,
     ok.
 
@@ -639,14 +635,14 @@ multiple_monsters_and_rooms(Config) ->
          <<"rooms">> := [#{<<"id">> := Room1}]}
      } = run(Config, <<"MultipleRooms">>, #{ <<"ids">> => [Room1]}),
     % look for an existing room and a non existing room
+    Result = run(Config, <<"MultipleRooms">>, #{ <<"ids">> => [Room1, NonExistentRoom]}),
     #{ data := #{ <<"rooms">> := owl },
        errors :=
            [#{path := [<<"MultipleRooms">>, <<"rooms">>, 1],
               key := null_value },
             #{path := [<<"MultipleRooms">>, <<"rooms">>, 1],
               key := not_found } ]
-     } = run(Config, <<"MultipleRooms">>,
-             #{ <<"ids">> => [Room1, NonExistentRoom]}),
+     } = Result,
     ok.
 
 inline_fragment(Config) ->

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -73,11 +73,9 @@ gray(#{ r := R,
     #{ r => V, g => V, b => V }.
 
 stats(owl) -> {ok, owl};
-stats(null) -> {ok, owl};
 stats(SS) -> {ok, [{ok, S} || S <- SS]}.
 
 stats(owl, _) -> {ok, owl};
-stats(null, _) -> {ok, owl};
 stats(SS, #{ <<"minAttack">> := Min }) ->
     {ok, [{ok, S} || S <- SS,
                      S#stats.attack >= Min]}.

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -72,13 +72,12 @@ gray(#{ r := R,
     V = 0.30*R + 0.59*G + 0.11*B,
     #{ r => V, g => V, b => V }.
 
-stats(null) ->
-    {ok, null};
-stats(SS) ->
-    {ok, [{ok, S} || S <- SS]}.
+stats(owl) -> {ok, owl};
+stats(null) -> {ok, owl};
+stats(SS) -> {ok, [{ok, S} || S <- SS]}.
 
-stats(null, _) ->
-    {ok, null};
+stats(owl, _) -> {ok, owl};
+stats(null, _) -> {ok, owl};
 stats(SS, #{ <<"minAttack">> := Min }) ->
     {ok, [{ok, S} || S <- SS,
                      S#stats.attack >= Min]}.

--- a/test/dungeon_mutation.erl
+++ b/test/dungeon_mutation.erl
@@ -72,7 +72,6 @@ execute(_Ctx, _, <<"spawnMinion">>, #{ <<"input">> := Input }) ->
 
 %% -- INTERNAL FUNCTIONS ----------------------------
 input_stats(owl) -> owl;
-input_stats(null) -> null;
 input_stats([]) -> [];
 input_stats([#{ <<"attack">> := Attack,
                 <<"shellScripting">> := SHScript,

--- a/test/dungeon_mutation.erl
+++ b/test/dungeon_mutation.erl
@@ -27,13 +27,13 @@ execute(_Ctx, _, <<"introduceMonster">>, #{ <<"input">> := Input }) ->
             exit({bad_mood_value, M})
     end,
     {atomic, Monster} = dungeon:insert(#monster {
-    	properties = Props,
-    	plush_factor = PF,
-    	stats = Ss,
-    	name = N,
-    	color = C,
-    	hitpoints = HP,
-    	mood = M }),
+        properties = Props,
+        plush_factor = PF,
+        stats = Ss,
+        name = N,
+        color = C,
+        hitpoints = HP,
+        mood = M }),
     {ok, #{
         <<"clientMutationId">> => MID,
         <<"monster">> => Monster } };
@@ -68,9 +68,10 @@ execute(_Ctx, _, <<"spawnMinion">>, #{ <<"input">> := Input }) ->
           end,
     {atomic, Result} = mnesia:transaction(Txn),
     {ok, Result#{ <<"clientMutationId">> => MID }}.
-    
+
 
 %% -- INTERNAL FUNCTIONS ----------------------------
+input_stats(owl) -> owl;
 input_stats(null) -> null;
 input_stats([]) -> [];
 input_stats([#{ <<"attack">> := Attack,

--- a/test/dungeon_object.erl
+++ b/test/dungeon_object.erl
@@ -2,7 +2,6 @@
 -export([execute/4]).
 
 execute(_Ctx, Obj, Field, _) when is_map(Obj) ->
-    {ok, maps:get(Field, Obj, null)};
+    {ok, maps:get(Field, Obj, owl)};
 execute(_Ctx, Obj, _, _) ->
     {error, {not_map_object, Obj}}.
-

--- a/test/dungeon_query.erl
+++ b/test/dungeon_query.erl
@@ -39,4 +39,3 @@ execute(_Ctx, _, <<"rooms">>, #{ <<"ids">> := InputIDs }) ->
 execute(Ctx, _, <<"roll">>, Args) ->
     TimeOut = maps:get(<<"delay">>,  Args, 0),
     {ok, #dice{ delay = TimeOut } }.
-

--- a/test/dungeon_stats.erl
+++ b/test/dungeon_stats.erl
@@ -12,7 +12,7 @@ execute(Ctx, #stats { attack = Attack,
             AttackToken = graphql:token(Ctx),
             spawn_link(fun() ->
                                Reply = case Attack of
-                                           13 -> {ok, null};
+                                           13 -> {ok, owl};
                                            A -> {ok, A}
                                        end,
                                graphql:reply_cast(AttackToken, Reply)
@@ -23,4 +23,3 @@ execute(Ctx, #stats { attack = Attack,
         <<"shellScripting">> ->
             {ok, ShellScripting}
     end.
-

--- a/test/enum_SUITE.erl
+++ b/test/enum_SUITE.erl
@@ -96,7 +96,7 @@ no_string_literal(Config) ->
 no_incorrect_internal_value(Config) ->
     Q1 = "{ colorEnum(fromString: \"YELLOW\") }",
     #{ data := #{
-        <<"colorEnum">> := null }} = th:x(Config, Q1),
+        <<"colorEnum">> := owl }} = th:x(Config, Q1),
     ok.
 
 no_internal_enum(Config) ->
@@ -148,8 +148,7 @@ internal_zero(Config) ->
 input_nullable(Config) ->
     Q1 = "{ colorEnum colorInt }",
     #{ data := #{
-        <<"colorEnum">> := null,
-        <<"colorInt">> := null
+        <<"colorEnum">> := owl,
+        <<"colorInt">> := owl
     }} = th:x(Config, Q1),
     ok.
-

--- a/test/graphql_SUITE.erl
+++ b/test/graphql_SUITE.erl
@@ -144,7 +144,7 @@ schema_test(Config) ->
                     <<"body">> := <<"This is a post">>,
                     <<"id">> := <<"1">>,
                     <<"isPublished">> := true,
-                    <<"keywords">> := [<<"foo">>,<<"bar">>, null, null, null],
+                    <<"keywords">> := [<<"foo">>,<<"bar">>, owl, owl, owl],
                     <<"title">> := <<"My article number 1">>
                 }
             },

--- a/test/schema_colors.erl
+++ b/test/schema_colors.erl
@@ -4,43 +4,43 @@
 
 inject() ->
      Color = {enum, #{
-     	id => 'Color',
-     	description => "A test representation of color",
-     	values => #{
-     	    <<"RED">> => #{ value => 0, description => "The color red" },
-     	    <<"GREEN">> => #{ value => 1, description => "The color green" },
-     	    <<"BLUE">> => #{ value => 2, description => "The color blue" }
-     	}
+        id => 'Color',
+        description => "A test representation of color",
+        values => #{
+            <<"RED">> => #{ value => 0, description => "The color red" },
+            <<"GREEN">> => #{ value => 1, description => "The color green" },
+            <<"BLUE">> => #{ value => 2, description => "The color blue" }
+        }
      }},
      ok = graphql:insert_schema_definition(Color),
 
      Query = {object, #{
-     	id => 'Query',
-     	description => "Top level query object",
-     	fields => #{
-     		colorEnum => #{
-     			type => 'Color',
-     			description => "A color enumerated type",
-     			args => #{
-     				'fromEnum' =>
-     				    #{ type => 'Color', description => "" },
-				'fromInt' =>
-				    #{ type => 'Int', description => "" },
-				'fromString' =>
-				    #{ type => 'String', description => "" }
-			},
-			resolve => fun color_enum/3
-		},
-		colorInt => #{
-			type => 'Int',
-			description => "Colors as integers",
-			args => #{
-				fromEnum => #{ type => 'Color', description => "" },
-				fromInt => #{ type => 'Int', description => "" }
-			},
-			resolve => fun color_int/3
-		}
-	}
+        id => 'Query',
+        description => "Top level query object",
+        fields => #{
+            colorEnum => #{
+                type => 'Color',
+                description => "A color enumerated type",
+                args => #{
+                    'fromEnum' =>
+                        #{ type => 'Color', description => "" },
+                'fromInt' =>
+                    #{ type => 'Int', description => "" },
+                'fromString' =>
+                    #{ type => 'String', description => "" }
+            },
+            resolve => fun color_enum/3
+        },
+        colorInt => #{
+            type => 'Int',
+            description => "Colors as integers",
+            args => #{
+                fromEnum => #{ type => 'Color', description => "" },
+                fromInt => #{ type => 'Int', description => "" }
+            },
+            resolve => fun color_int/3
+        }
+    }
     }},
     ok = graphql:insert_schema_definition(Query),
 
@@ -48,20 +48,20 @@ inject() ->
         id => 'Mutation',
         description => "Top level mutation query",
         fields => #{
-        		favoriteEnum => #{
-        			type => 'Color',
-        			args => #{
-        				color => #{ type => 'Color', description => "" }
-        			},
-        			resolve => fun
-        			    (_, _V, #{ <<"color">> :=  C }) -> {ok, C};
-        			    (_, _V, #{}) -> {error, cannot_resolve_color}
-        			end
-        		}
-        	}
+                favoriteEnum => #{
+                    type => 'Color',
+                    args => #{
+                        color => #{ type => 'Color', description => "" }
+                    },
+                    resolve => fun
+                        (_, _V, #{ <<"color">> :=  C }) -> {ok, C};
+                        (_, _V, #{}) -> {error, cannot_resolve_color}
+                    end
+                }
+            }
     }},
     ok = graphql:insert_schema_definition(Mutation),
-    
+
     Root = {root, #{
        query => 'Query',
        mutation => 'Mutation',
@@ -87,37 +87,36 @@ resolve_output(enum, 'BLUE') -> {ok, <<"BLUE">>};
 resolve_output(int, 'RED') -> {ok, 0};
 resolve_output(int, 'GREEN') -> {ok, 1};
 resolve_output(int, 'BLUE') -> {ok, 2}.
-    
+
 color_enum(_Ctx, _, #{
-    <<"fromEnum">> := null,
-    <<"fromInt">> := null,
-    <<"fromString">> := null}) -> {ok, null};
+    <<"fromEnum">> := owl,
+    <<"fromInt">> := owl,
+    <<"fromString">> := owl}) -> {ok, owl};
 color_enum(_Ctx, _, #{
     <<"fromEnum">> := X,
-    <<"fromInt">> := null,
-    <<"fromString">> := null}) -> resolve_output(enum,
+    <<"fromInt">> := owl,
+    <<"fromString">> := owl}) -> resolve_output(enum,
                                     resolve_input(enum, X));
 color_enum(_Ctx, _, #{
-    <<"fromEnum">> := null,
+    <<"fromEnum">> := owl,
     <<"fromInt">> := X,
-    <<"fromString">> := null})
+    <<"fromString">> := owl})
   when X >= 0 andalso X < 3 -> resolve_output(enum,
                                  resolve_input(int, X));
 color_enum(_Ctx, _, #{
-    <<"fromEnum">> := null,
-    <<"fromInt">> := null,
+    <<"fromEnum">> := owl,
+    <<"fromInt">> := owl,
     <<"fromString">> := X}) -> resolve_output(enum,
                                  resolve_input(string, X)).
 
 color_int(_Ctx, _, #{
-    <<"fromEnum">> := null,
-    <<"fromInt">> := null }) -> {ok, null};
+    <<"fromEnum">> := owl,
+    <<"fromInt">> := owl }) -> {ok, owl};
 color_int(_Ctx, _, #{
-    <<"fromEnum">> := null,
-    <<"fromInt">> := X}) when X /= null -> resolve_output(int,
-                                             resolve_input(int, X));
+    <<"fromEnum">> := owl,
+    <<"fromInt">> := X}) when X /= owl -> resolve_output(int,
+                                                         resolve_input(int, X));
 color_int(_Ctx, _, #{
     <<"fromEnum">> := X,
-    <<"fromInt">> := null }) when X /= null -> resolve_output(int,
-                                                 resolve_input(enum, X)).
-
+    <<"fromInt">> := owl }) when X /= owl -> resolve_output(int,
+                                                            resolve_input(enum, X)).

--- a/test/schema_star_wars.erl
+++ b/test/schema_star_wars.erl
@@ -35,7 +35,7 @@ inject() ->
                    resolve => fun(Ctx, _Cur, Args) -> get_droid(Ctx, Args) end }
                 } } },
     ok = graphql:insert_schema_definition(Query),
-    
+
     Root = {root, #{
               query => 'Query',
               interaces => []
@@ -133,8 +133,8 @@ init_starwars() ->
     ok.
 
 %% Execution
-execute(_Ctx, null, _, _) ->
-    {ok, null};
+execute(Ctx, owl, _, _) ->
+    {ok, owl};
 execute(_Ctx, Obj, FieldName, _Args) ->
     case maps:get(FieldName, Obj, not_found) of
         {'$lazy', F} when is_function(F, 0) -> F();
@@ -142,7 +142,7 @@ execute(_Ctx, Obj, FieldName, _Args) ->
         Values when is_list(Values) -> {ok, [ {ok, R} || R <- Values ]};
         Value -> {ok, Value}
     end.
-    
+
 %% DATA
 is_human(ID) ->
     {Humans, _} = star_wars(),
@@ -151,7 +151,7 @@ is_human(ID) ->
 get_character(ID) ->
     {Humans, Droids} = star_wars(),
     case maps:get(ID, maps:merge(Humans, Droids), not_found) of
-        not_found -> {ok, null};
+        not_found -> {ok, owl};
         X -> {ok, X}
     end.
 
@@ -167,69 +167,69 @@ get_hero(_Ctx, _) ->
 
 get_human(_Ctx, #{ <<"id">> := ID }) ->
     {Humans, _} = star_wars(),
-    {ok, maps:get(ID, Humans, null)}.
+    {ok, maps:get(ID, Humans, owl)}.
 
 get_droid(_Ctx, #{ <<"id">> := ID }) ->
     {_, Droids} = star_wars(),
-    {ok, maps:get(ID, Droids, null)}.
+    {ok, maps:get(ID, Droids, owl)}.
 
 star_wars() ->
     Luke = #{
-    	id => <<"1000">>,
-    	name => <<"Luke Skywalker">>,
-    	friends => [<<"1002">>,<< "1003">>, <<"2000">>, <<"2001">> ],
-    	appearsIn => resolve_module([ 4, 5, 6 ]),
-    	homePlanet => <<"Tatooine">> },
+        id => <<"1000">>,
+        name => <<"Luke Skywalker">>,
+        friends => [<<"1002">>,<< "1003">>, <<"2000">>, <<"2001">> ],
+        appearsIn => resolve_module([ 4, 5, 6 ]),
+        homePlanet => <<"Tatooine">> },
     Vader = #{
-    	id => <<"1001">>,
-    	name => <<"Darth Vader">>,
-    	friends => [<<"1004">>],
-    	appearsIn => resolve_module([ 4, 5, 6 ]),
-    	homePlanet => <<"Tatooine">> },
+        id => <<"1001">>,
+        name => <<"Darth Vader">>,
+        friends => [<<"1004">>],
+        appearsIn => resolve_module([ 4, 5, 6 ]),
+        homePlanet => <<"Tatooine">> },
     Han = #{
-    	id => <<"1002">>,
-    	name => <<"Han Solo">>,
-    	friends => [<<"1000">>, <<"1003">>, <<"2001">>],
-    	appearsIn => resolve_module([ 4, 5, 6])},
+        id => <<"1002">>,
+        name => <<"Han Solo">>,
+        friends => [<<"1000">>, <<"1003">>, <<"2001">>],
+        appearsIn => resolve_module([ 4, 5, 6])},
     Leia = #{
-    	id => <<"1003">>,
-    	name => <<"Leia Organa">>,
-    	friends => [<<"1000">>, <<"1002">>, <<"2000">>, <<"2001">> ],
-    	appearsIn => resolve_module([ 4, 5, 6]),
-    	homePlanet => <<"Alderaan">> },
+        id => <<"1003">>,
+        name => <<"Leia Organa">>,
+        friends => [<<"1000">>, <<"1002">>, <<"2000">>, <<"2001">> ],
+        appearsIn => resolve_module([ 4, 5, 6]),
+        homePlanet => <<"Alderaan">> },
     Tarkin = #{
-    	id => <<"1004">>,
-    	name => <<"Wilhuff Tarkin">>,
-    	friends => [ <<"1001">> ],
-    	appearsIn => resolve_module([ 4 ]) },
+        id => <<"1004">>,
+        name => <<"Wilhuff Tarkin">>,
+        friends => [ <<"1001">> ],
+        appearsIn => resolve_module([ 4 ]) },
 
     HumanData = #{
-    	<<"1000">> => c(Luke),
-    	<<"1001">> => c(Vader),
-    	<<"1002">> => c(Han),
-    	<<"1003">> => c(Leia),
-    	<<"1004">> => c(Tarkin)
+        <<"1000">> => c(Luke),
+        <<"1001">> => c(Vader),
+        <<"1002">> => c(Han),
+        <<"1003">> => c(Leia),
+        <<"1004">> => c(Tarkin)
     },
 
     Threepio = #{
-    	id => <<"2000">>,
-    	name => <<"C-3PO">>,
-    	friends => [ <<"1000">>, <<"1002">>, <<"1003">>, <<"2001">> ],
-    	appearsIn => resolve_module([ 4, 5, 6 ]),
-    	primaryFunction => <<"Protocol">>
+        id => <<"2000">>,
+        name => <<"C-3PO">>,
+        friends => [ <<"1000">>, <<"1002">>, <<"1003">>, <<"2001">> ],
+        appearsIn => resolve_module([ 4, 5, 6 ]),
+        primaryFunction => <<"Protocol">>
     },
 
     Artoo = #{
-    	id => <<"2001">>,
-    	name => <<"R2-D2">>,
-    	friends => [ <<"1000">>, <<"1002">>, <<"1003">> ],
-    	appearsIn => resolve_module([ 4, 5, 6 ]),
-    	primaryFunction => <<"AstroMech">>
+        id => <<"2001">>,
+        name => <<"R2-D2">>,
+        friends => [ <<"1000">>, <<"1002">>, <<"1003">> ],
+        appearsIn => resolve_module([ 4, 5, 6 ]),
+        primaryFunction => <<"AstroMech">>
     },
 
     DroidData = #{
-    	<<"2000">> => c(Threepio),
-    	<<"2001">> => c(Artoo)
+        <<"2000">> => c(Threepio),
+        <<"2001">> => c(Artoo)
     },
 
     {HumanData, DroidData}.
@@ -237,26 +237,26 @@ star_wars() ->
 c(M) ->
     Unpacked = maps:to_list(M),
     maps:from_list(
-    	[{atom_to_binary(K, utf8), V} || {K, V} <- Unpacked]).
+        [{atom_to_binary(K, utf8), V} || {K, V} <- Unpacked]).
 
 resolve_arg(X) ->
     case X of
-	<<"NEWHOPE">> ->
- 	    4;
- 	<<"EMPIRE">> ->
- 	    5;
- 	<<"JEDI">> ->
- 	    6;
- 	'_' ->
- 	    {error, {invalid_episode_string, X}};
-	4 ->
-  	    <<"NEWHOPE">>;
- 	5 ->
-  	    <<"EMPIRE">>;
-  	6 ->
-  	    <<"JEDI">>;
-  	_ ->
-  	    {error, {invalid_episode_int, X}}
+    <<"NEWHOPE">> ->
+        4;
+    <<"EMPIRE">> ->
+        5;
+    <<"JEDI">> ->
+        6;
+    '_' ->
+        {error, {invalid_episode_string, X}};
+    4 ->
+        <<"NEWHOPE">>;
+    5 ->
+        <<"EMPIRE">>;
+    6 ->
+        <<"JEDI">>;
+    _ ->
+        {error, {invalid_episode_int, X}}
      end.
 
 map(F, [H|T]) -> [F(H)|map(F, T)];

--- a/test/star_wars_SUITE.erl
+++ b/test/star_wars_SUITE.erl
@@ -169,7 +169,7 @@ query_id_params(Config) ->
             #{ <<"name">> := <<"Han Solo">> } } } =
                 th:x(Config, Q2, <<"FetchSomeIDQuery">>, #{ <<"someID">> => <<"1002">> }),
     #{ data :=
-        #{ <<"human">> := null } } =
+        #{ <<"human">> := owl } } =
             th:x(Config, Q2, <<"FetchSomeIDQuery">>, #{ <<"someID">> => <<"Not a valid query">> }),
     ok.
 

--- a/test/test.spec
+++ b/test/test.spec
@@ -1,2 +1,3 @@
 {suites, ".", all}.
+{skip_cases, ".", dungeon_SUITE, introspection, "The graphql introspection module need some work to support custom null values"}.
 {skip_cases, ".", dungeon_SUITE, introspection_with_variable, "This test is waiting for #107 to be fixed"}.

--- a/test/th.erl
+++ b/test/th.erl
@@ -30,14 +30,14 @@ x(Config, Input, OpName, Params) ->
                Track3 = track(type_check, Track2),
                CoercedParams = graphql:type_check_params(FunEnv, OpName, Params),
                Track4 = track(type_check_params, Track3),
-               Ctx = #{ params => CoercedParams },
+               Ctx = #{ params => CoercedParams, null_value => owl },
                ok = graphql:validate(AST2),
                Track5 = track(validate, Track4),
                Res = case OpName of
                          undefined -> graphql:execute(Ctx, AST2);
                          Op -> graphql:execute(Ctx#{ operation_name => Op }, AST2)
                      end,
-               
+
                Track6 = track(execute, Track5),
                ct:log("Result: ~p", [Res]),
                track_report(Config, Track6),
@@ -88,7 +88,7 @@ v(Q) ->
 track_new() ->
     T = erlang:monotonic_time(),
     #{ '$last' => T }.
-    
+
 track(Event, #{ '$last' := Start } = M) ->
     End = erlang:monotonic_time(),
     Diff = erlang:convert_time_unit(End - Start, native, micro_seconds),
@@ -97,4 +97,3 @@ track(Event, #{ '$last' := Start } = M) ->
 track_report(Config, M) ->
     Name = proplists:get_value(name, ?config(tc_group_properties, Config)),
     ct:log("Timings ~p: ~p", [Name, maps:remove('$last', M)]).
-


### PR DESCRIPTION
This pull request aims to make the null value customisable, so we can support systems that use a different from 'null' value as its concept of null; systems such as Elixir, and perhaps protobuf.

So far I've carried the context through to the paths that seems to be relevant; the context now carry a key called `null_value` that eventually will be a configuration option. I've changed the `null` value to `owl`; it doesn't really make sense besides testing that a different atom can be used—the plan is to switch this to `null` when it has proved its point so we can get this into the system without causing too much trouble.

It should be said: I don't know much about this part of the code, so my approach has been poking around, adding log messages, and changing values…it seems to work for the most part (as of writing there is still some null values being propagated), but I am not sure it is the correct approach.

Work in progress—at least I know more about the `graphql-execution`-module than I did before.