### PR TITLE
Permit enum value dups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ the compatibility issues you are likely to encounter.
 ### Fix
 
 - The `key` field in errors are now an atom so it can be JSON encoded.
+- The same `enum` value can now be used in multiple `enum` types.
 
 ## [0.12.0] 2018-02-23 Flag day release, broke compatibility backwards!
 

--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -207,9 +207,9 @@ type_check_err_msg(non_null) ->
 type_check_err_msg({enum_not_found, Ty, Val}) ->
     X = io_lib:format("The value ~p is not a valid enum value for type ", [Val]),
     [X, graphql_err:format_ty(Ty)];
-type_check_err_msg({param_mismatch, {enum, Ty, OtherTy}}) ->
-    ["The enum value is of type ", graphql_err:format_ty(OtherTy),
-     " but used in a context where an enum value"
+type_check_err_msg({param_mismatch, {enum, Ty, OtherTys}}) ->
+    ["The enum value matches types ", graphql_err:format_ty(lists:sort(OtherTys)),
+     " but was used in a context where an enum value"
      " of type ", graphql_err:format_ty(Ty), " was expected"];
 type_check_err_msg({param_mismatch, Ty, V}) ->
     io_lib:format("The parameter value ~p is not of type ~p", [V, graphql_err:format_ty(Ty)]);

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -535,10 +535,11 @@ complete_value(Path, _Ctx, #enum_type { id = ID,
         {ok, null, Errors} ->
             {ok, null, Errors};
         {ok, Result, Errors} ->
-            case graphql_schema:lookup_enum_type(Result) of
-                #enum_type { id = ID } ->
+
+            case graphql_schema:validate_enum(ID, Result) of
+                ok ->
                     {ok, Result, Errors};
-                #enum_type {} ->
+                {other_enums, _EnumTypes} ->
                     null(Path, {invalid_enum_output, ID, Result}, Errors);
                 not_found ->
                     null(Path, {invalid_enum_output, ID, Result}, Errors)

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -414,6 +414,28 @@ populate(Config) ->
                                        <<"I LOVE WEAVING!">>}]}}}},
 
     ExpectedNestedInput = run(Config, <<"IntroduceMonsterNestedVar">>, NestedInput),
+
+    ct:log("Check duplicate enum values (BEAST mood/property)"),
+
+    DupEnumInput = #{
+        <<"clientMutationId">> => <<"MUTID">>,
+        <<"name">> => <<"orc">>,
+        <<"color">> => <<"#593E1A">>,
+        <<"hitpoints">> => 30,
+        <<"properties">> => [<<"BEAST">>],
+        <<"mood">> => <<"BEAST">>
+    },
+    #{ data := #{
+        <<"introduceMonster">> := #{
+            <<"clientMutationId">> := <<"MUTID">>,
+            <<"monster">> := #{
+                <<"id">> := _,
+                <<"name">> := <<"orc">>,
+                <<"color">> := <<"#593E1A">>,
+                <<"hitpoints">> := 30,
+                <<"properties">> := [<<"BEAST">>],
+                <<"mood">> := <<"BEAST">>}
+        }}} = run(Config, <<"IntroduceMonster">>, #{ <<"input">> => DupEnumInput }),
     ok.
 
 direct_input(Config) ->
@@ -902,6 +924,11 @@ invalid_enums(Config) ->
              message := <<"The value <<>> is not a valid enum value for type Mood">>,
              path := [<<"IntroduceMonster">>,<<"input">>,<<"mood">>]}]} =
           run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input#{ <<"mood">> => <<>> }}),
+    #{errors :=
+      [#{key := param_mismatch,
+         message := <<"The enum value matches types [Property] but was used in a context where an enum value of type Mood was expected">>,
+         path := [<<"IntroduceMonster">>,<<"input">>,<<"mood">>]}]} =
+        run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input#{ <<"mood">> => <<"DRAGON">> }}),
     #{ errors :=
            [#{ key := enum_not_found,
                message := <<"The value <<\"AGGRESSIF\">> is not a valid enum value for type Mood">>,

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -8,6 +8,8 @@ enum Mood {
      DODGY
      +description(text: "This monster attacks every living being, including itself")
      AGGRESSIVE
+     +description(text: "Beast mode.  Even worse")
+     BEAST
 }
 
 enum Property {

--- a/test/dungeon_enum.erl
+++ b/test/dungeon_enum.erl
@@ -11,6 +11,7 @@ input(<<"Mood">>, X) ->
 output(<<"Mood">>, 'DODGY') -> {ok, <<"DODGY">>};
 output(<<"Mood">>, 'TRANQUIL') -> {ok, <<"TRANQUIL">>};
 output(<<"Mood">>, 'AGGRESSIVE') -> {ok, <<"AGGRESSIVE">>};
+output(<<"Mood">>, 'BEAST') -> {ok, <<"BEAST">>};
 %% This is a deliberate error case
 output(<<"Mood">>, <<"INVALIDMOOD">>) -> {ok, <<"INVALIDMOOD">>}.
 

--- a/test/graphql_SUITE_data/test_schema.spec
+++ b/test/graphql_SUITE_data/test_schema.spec
@@ -35,6 +35,7 @@ enum Mood {
 	TRANQUIL
 	DODGY
 	AGGRESSIVE
+	BEAST
 }
 
 enum Property {


### PR DESCRIPTION
Fixes issue #156 "duplicate enum values don't work"
    
- enum table now stores set of enum type ids instead of just one
- dropped integer value from enum table because it wasn't used anywhere
- lookup_enum_type() removed because it may resolve to more than one type
- replaced with validate_enum()
- update enum error message to deal with multiple matches

