### PR TITLE
add multi endpoint support [wip]

### DIFF
--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -5,10 +5,12 @@
 %% GraphQL Documents
 -export([
          parse/1,
-         elaborate/1,
-         type_check/1, type_check_params/3,
+         elaborate/1, p_elaborate/2, ep_elaborate/2,
+         type_check/1, p_type_check/2, ep_type_check/2,
+         type_check_params/3, p_type_check_params/4, ep_type_check_params/4,
          validate/1,
-         execute/1, execute/2
+         execute/1, p_execute/2, ep_execute/2,
+         execute/2, p_execute/3, ep_execute/3
         ]).
 
 -export([
@@ -27,9 +29,14 @@
 
 %% Schema Definitions
 -export([
-         load_schema/2,
-         insert_schema_definition/1,
-         validate_schema/0
+         load_schema/2, p_load_schema/3, ep_load_schema/3,
+         insert_schema_definition/1, p_insert_schema_definition/2, ep_insert_schema_definition/2,
+         validate_schema/0, p_validate_schema/1, ep_validate_schema/1
+]).
+
+-export([
+    get_endpoint/1,
+    default_endpoint/0
 ]).
 
 %% Internal
@@ -49,6 +56,15 @@
 -export_type([schema_field/0]).
 
 -define(DEFAULT_TIMEOUT, 750).
+
+
+%% Endpoints
+-type server_ref() :: pid() | atom().
+-type endpoint_context() :: graphql_schema:endpoint_context().
+
+
+
+
 
 %% EARLY EXIT
 %% --------------------------------------------------------------------------
@@ -93,14 +109,21 @@ parse(Input) when is_list(Input) ->
             {error, {scanner_error, Err}}
     end.
 
-load_schema(Mapping, Input) when is_binary(Input) ->
-    load_schema(Mapping, binary_to_list(Input));
-load_schema(Mapping, Input) when is_list(Input) ->
+
+
+%% Endpoint API
+%% All calls require an endpoint_context() which can be acquired with
+%% get_endpoint(server_ref()) and default_endpoint().
+
+
+ep_load_schema(EP, Mapping, Input) when is_binary(Input) ->
+    ep_load_schema(EP, Mapping, binary_to_list(Input));
+ep_load_schema(EP, Mapping, Input) when is_list(Input) ->
     case graphql_scanner:string(Input) of
         {ok, Tokens, _EndLine} ->
             case graphql_parser:parse(Tokens) of
                 {ok, _} = Result ->
-                    graphql_schema_parse:inject(Mapping, Result);
+                    graphql_schema_parse:inject(EP, Mapping, Result);
                 {error, Err} ->
                     {error, Err}
             end;
@@ -108,32 +131,26 @@ load_schema(Mapping, Input) when is_list(Input) ->
             {error, Err}
     end.
 
--spec validate(ast()) -> ok | {error, term()}.
-validate(AST) ->
-    graphql_validate:x(AST).
+-spec ep_type_check(endpoint_context(), ast()) -> {ok, #{ atom() => term() }}.
+ep_type_check(EP, AST) ->
+    graphql_type_check:x(EP, AST).
 
--spec type_check(ast()) -> {ok, #{ atom() => term() }}.
-type_check(AST) ->
-    graphql_type_check:x(AST).
+-spec ep_elaborate(endpoint_context(), ast()) -> ast().
+ep_elaborate(EP, AST) ->
+    graphql_elaborate:x(EP, AST).
 
--spec elaborate(ast()) -> ast().
-elaborate(AST) ->
-   graphql_elaborate:x(AST).
+-spec ep_type_check_params(endpoint_context(), any(), any(), any()) -> param_context().
+ep_type_check_params(EP, FunEnv, OpName, Vars) ->
+    graphql_type_check:x_params(EP, FunEnv, OpName, Vars).
 
--spec type_check_params(any(), any(), any()) -> param_context().
-type_check_params(FunEnv, OpName, Vars) ->
-    graphql_type_check:x_params(FunEnv, OpName, Vars).
-
--spec execute(ast()) -> #{ atom() => json() }.
-execute(AST) ->
+-spec ep_execute(endpoint_context(), ast()) -> #{ atom() => json() }.
+ep_execute(EP, AST) ->
     Ctx = #{ params => #{}, default_timeout => ?DEFAULT_TIMEOUT },
-    execute(Ctx, AST).
+    ep_execute(EP, Ctx, AST).
 
--spec execute(context(), ast()) -> #{ atom() => json() }.
-execute(#{default_timeout := _DT } = Ctx, AST) ->
-    graphql_execute:x(Ctx, AST);
-execute(Ctx, AST) ->
-    case graphql_execute:x(Ctx#{ default_timeout => ?DEFAULT_TIMEOUT}, AST) of
+-spec ep_execute(endpoint_context(), context(), ast()) -> #{ atom() => json() }.
+ep_execute(EP, Ctx, AST) ->
+    case graphql_execute:x(EP, Ctx#{ default_timeout => ?DEFAULT_TIMEOUT}, AST) of
         #{ errors := Errs } = Result ->
             Result#{ errors := graphql_err:format_errors(Ctx, Errs) };
         Result -> Result
@@ -141,13 +158,95 @@ execute(Ctx, AST) ->
 
 %% @doc insert_schema_definition/1 loads a schema definition into the Graph Schema
 %% @end
+-spec ep_insert_schema_definition(endpoint_context(), schema_definition()) -> ok | {error, Reason}
+                                  when Reason :: term().
+ep_insert_schema_definition(EP, Defn) ->
+    graphql_schema:load(EP, Defn).
+
+%% STUB for now
+-spec ep_validate_schema(endpoint_context()) -> ok | {error, any()}.
+ep_validate_schema(EP) ->
+    graphql_schema_validate:x(EP).
+
+
+
+
+
+%% Pid API
+%% All calls require a pid()/atom() that refers to the schema gen_server.
+
+-spec get_endpoint(server_ref()) -> endpoint_context().
+get_endpoint(P) -> graphql_schema:get_endpoint(P).
+
+
+p_load_schema(P, Mapping, Input) -> ep_load_schema(get_endpoint(P), Mapping, Input).
+
+-spec p_type_check(server_ref(), ast()) -> {ok, #{ atom() => term() }}.
+p_type_check(P, AST) -> ep_type_check(get_endpoint(P), AST).
+
+-spec p_elaborate(server_ref(), ast()) -> ast().
+p_elaborate(P, AST) -> ep_elaborate(get_endpoint(P), AST).
+
+-spec p_type_check_params(server_ref(), any(), any(), any()) -> param_context().
+p_type_check_params(P, FunEnv, OpName, Vars) -> ep_type_check_params(get_endpoint(P), FunEnv, OpName, Vars).
+
+-spec p_execute(server_ref(), ast()) -> #{ atom() => json() }.
+p_execute(P, AST) -> ep_execute(get_endpoint(P), AST).
+
+-spec p_execute(server_ref(), context(), ast()) -> #{ atom() => json() }.
+p_execute(P, Ctx, AST) -> ep_execute(get_endpoint(P), Ctx, AST).
+
+%% @doc insert_schema_definition/1 loads a schema definition into the Graph Schema
+%% @end
+-spec p_insert_schema_definition(server_ref(), schema_definition()) -> ok | {error, Reason}
+                                     when Reason :: term().
+p_insert_schema_definition(P, Defn) -> ep_insert_schema_definition(get_endpoint(P), Defn).
+
+%% STUB for now
+-spec p_validate_schema(server_ref()) -> ok | {error, any()}.
+p_validate_schema(P) -> ep_validate_schema(get_endpoint(P)).
+
+
+%% Default Endpoint API
+%% All calls implicitly refer to the application default endpoint.
+
+-spec default_endpoint() -> endpoint_context().
+default_endpoint() -> get_endpoint(graphql_default_endpoint).
+
+
+load_schema(Mapping, Input) -> ep_load_schema(default_endpoint(), Mapping, Input).
+
+-spec type_check(ast()) -> {ok, #{ atom() => term() }}.
+type_check(AST) -> ep_type_check(default_endpoint(), AST).
+
+-spec elaborate(ast()) -> ast().
+elaborate(AST) -> ep_elaborate(default_endpoint(), AST).
+
+-spec type_check_params(any(), any(), any()) -> param_context().
+type_check_params(FunEnv, OpName, Vars) -> ep_type_check_params(default_endpoint(), FunEnv, OpName, Vars).
+
+-spec execute(ast()) -> #{ atom() => json() }.
+execute(AST) -> ep_execute(default_endpoint(), AST).
+
+-spec execute(context(), ast()) -> #{ atom() => json() }.
+execute(Ctx, AST) -> ep_execute(default_endpoint(), Ctx, AST).
+
+%% @doc insert_schema_definition/1 loads a schema definition into the Graph Schema
+%% @end
 -spec insert_schema_definition(schema_definition()) -> ok | {error, Reason}
-  when Reason :: term().
-insert_schema_definition(Defn) ->
-    graphql_schema:load(Defn).
+                                     when Reason :: term().
+insert_schema_definition(Defn) -> ep_insert_schema_definition(default_endpoint(), Defn).
 
 %% STUB for now
 -spec validate_schema() -> ok | {error, any()}.
-validate_schema() ->
-    graphql_schema_validate:x().
+validate_schema() -> ep_validate_schema(default_endpoint()).
+
+
+
+%% Schema Independent API
+%% Use in conjunction with any of the above API variants.
+
+-spec validate(ast()) -> ok | {error, term()}.
+validate(AST) ->
+    graphql_validate:x(AST).
 

--- a/src/graphql_builtins.erl
+++ b/src/graphql_builtins.erl
@@ -2,11 +2,11 @@
 
 -include("graphql_schema.hrl").
 
--export([directive_schema/1]).
--export([standard_types_inject/0]).
+-export([directive_schema/2]).
+-export([standard_types_inject/1]).
 
--spec standard_types_inject() -> ok.
-standard_types_inject() ->
+-spec standard_types_inject(graphql_schema:endpoint_context()) -> ok.
+standard_types_inject(EP) ->
     String = {scalar, #{
     	id => 'String',
     	description => <<"UTF-8 Text Strings"/utf8>> }},
@@ -22,33 +22,33 @@ standard_types_inject() ->
     ID = {scalar, #{
     	id => 'ID',
     	description => <<"Representation of an opaque ID in the system. Always returned/given as strings, but clients are not allowed to deconstruct them. The server might change them as it sees fit later on, and the clients must be able to handle this situation."/utf8>> }},
-    ok = graphql:insert_schema_definition(String),
-    ok = graphql:insert_schema_definition(Float),
-    ok = graphql:insert_schema_definition(Int),
-    ok = graphql:insert_schema_definition(Bool),
-    ok = graphql:insert_schema_definition(ID),
+    ok = graphql:ep_insert_schema_definition(EP, String),
+    ok = graphql:ep_insert_schema_definition(EP, Float),
+    ok = graphql:ep_insert_schema_definition(EP, Int),
+    ok = graphql:ep_insert_schema_definition(EP, Bool),
+    ok = graphql:ep_insert_schema_definition(EP, ID),
     ok.
 
 %% Construct schema types for the directives the system supports
-directive_schema(include) ->
+directive_schema(EP, include) ->
     #directive_type {
        id = <<"include">>,
        locations = [field, fragment_spread, inline_fragment],
        args = #{
          <<"if">> =>
              #schema_arg{
-                ty = graphql_schema:get(<<"Bool">>),
+                ty = graphql_schema:get(EP, <<"Bool">>),
                 default = false,
                 description = <<"Wether or not the item should be included">> }
         }};
-directive_schema(skip) ->
+directive_schema(EP, skip) ->
     #directive_type {
        id = <<"skip">>,
        locations = [field, fragment_spread, inline_fragment],
        args = #{
          <<"if">> =>
              #schema_arg{
-                ty = graphql_schema:get(<<"Bool">>),
+                ty = graphql_schema:get(EP, <<"Bool">>),
                 default = false,
                 description = <<"Wether or not the item should be skipped">> }
         }}.

--- a/src/graphql_dot.erl
+++ b/src/graphql_dot.erl
@@ -5,14 +5,15 @@
 -export([dump/1]).
 
 -spec dump(string()) -> ok.
-dump(FName) ->
-    Graph = x(),
+dump(FName) -> ep_dump(graphql:default_endpoint(), FName).
+ep_dump(EP, FName) ->
+    Graph = x(EP),
     file:write_file(FName, Graph).
 
-x() ->
+x(EP) ->
     H = header(),
     F = footer(),
-    Body = body(),
+    Body = body(EP),
     [H, Body, F].
 
 footer() -> "}\n".
@@ -30,8 +31,8 @@ header() ->
      "  nodesep=0.3;",
      "  remincross=true;"]).
 
-body() ->
-    Entries = graphql_schema:all(),
+body(EP) ->
+    Entries = graphql_schema:all(EP),
     Map = maps:from_list([{id(E), E} || E <- Entries]),
     [
       [format(entry(E, Map)) || E <- Entries],

--- a/src/graphql_elaborate.erl
+++ b/src/graphql_elaborate.erl
@@ -3,21 +3,21 @@
 -include("graphql_schema.hrl").
 -include("graphql_internal.hrl").
 
--export([x/1]).
--export([type/1]).
+-export([x/2]).
+-export([type/2]).
 -export([mk_varenv/1, mk_funenv/1]).
 
--spec x(graphql:ast()) -> graphql:ast().
-x(Doc) -> document(Doc).
+-spec x(graphql_schema:endpoint_context(), graphql:ast()) -> graphql:ast().
+x(EP, Doc) -> document(EP, Doc).
 
-document({document, Ops}) ->
-    {document, operations([document], Ops)}.
+document(EP, {document, Ops}) ->
+    {document, operations(EP, [document], Ops)}.
 
-operations(Path, Operations) ->
-    [operation_(Path, Op) || Op <- Operations].
+operations(EP, Path, Operations) ->
+    [operation_(EP, Path, Op) || Op <- Operations].
 
-operation_(Path, #frag{} = F) -> frag(Path, fragment_definition, F);
-operation_(Path, #op{} = O) -> op(Path, O).
+operation_(EP, Path, #frag{} = F) -> frag(EP, Path, fragment_definition, F);
+operation_(EP, Path, #op{} = O) -> op(EP, Path, O).
 
 %% -- VARIABLE ENVIRONMENTS -----------------------
 
@@ -51,25 +51,25 @@ mk_funenv(Ops) ->
 
 %% Elaborate a type and also determine its polarity. This is used for
 %% input and output types
-type({non_null, Ty}) ->
-    case type(Ty) of
+type(EP, {non_null, Ty}) ->
+    case type(EP, Ty) of
         {error, Reason} -> {error, Reason};
         {Polarity, V} -> {Polarity, {non_null, V}}
     end;
-type({list, Ty}) ->
-    case type(Ty) of
+type(EP, {list, Ty}) ->
+    case type(EP, Ty) of
         {error, Reason} -> {error, Reason};
         {Polarity, V} -> {Polarity, {list, V}}
     end;
-type({scalar, Name}) ->
-    #scalar_type{} = Ty = graphql_schema:get(Name),
-    {_polarity, Ty} = type(Ty);
-type(#scalar_type{} = Ty) -> {'*', Ty};
-type({enum, _} = E) -> {'*', E};
-type(#enum_type{} = Ty) -> {'*', Ty};
-type({name, _, N}) -> type(N);
-type(N) when is_binary(N) ->
-    case graphql_schema:lookup(N) of
+type(EP, {scalar, Name}) ->
+    #scalar_type{} = Ty = graphql_schema:get(EP, Name),
+    {_polarity, Ty} = type(EP, Ty);
+type(_EP, #scalar_type{} = Ty) -> {'*', Ty};
+type(_EP, {enum, _} = E) -> {'*', E};
+type(_EP, #enum_type{} = Ty) -> {'*', Ty};
+type(EP, {name, _, N}) -> type(EP, N);
+type(EP, N) when is_binary(N) ->
+    case graphql_schema:lookup(EP, N) of
         not_found -> {error, not_found};
         %% Non-polar types
         #enum_type{} = Enum -> {'*', Enum};
@@ -85,8 +85,8 @@ type(N) when is_binary(N) ->
     end.
 
 %% Assert a type is an input type
-input_type(Ty) ->
-    case type(Ty) of
+input_type(EP, Ty) ->
+    case type(EP, Ty) of
         {error, Reason} -> {error, Reason};
         {'*', V} -> {ok, V};
         {'+', V} -> {ok, V};
@@ -94,8 +94,8 @@ input_type(Ty) ->
     end.
 
 %% Assert a type is an output type
-output_type(Ty) ->
-    case type(Ty) of
+output_type(EP, Ty) ->
+    case type(EP, Ty) of
         {error, Reason} -> {error, Reason};
         {'*', V} -> {ok, V};
         {'-', V} -> {ok, V};
@@ -104,8 +104,8 @@ output_type(Ty) ->
 
 
 %% -- ROOT ----------------------------------------
-root(Path, #op { ty = T } = Op) ->
-    case graphql_schema:lookup('ROOT') of
+root(EP, Path, #op { ty = T } = Op) ->
+    case graphql_schema:lookup(EP, 'ROOT') of
         not_found -> err([Op | Path], no_root_schema);
         Schema -> graphql_schema:resolve_root_type(T, Schema)
     end.
@@ -118,32 +118,32 @@ root(Path, #op { ty = T } = Op) ->
 %% other case, we have a type, but no schema entry. For that variant,
 %% we lookup the schema type, elaborate the fragment with the type and
 %% recurse.
-frag(Path, Context, #frag { ty = undefined, directives = Dirs } = Frag) ->
-    frag_sset(Path,
+frag(EP, Path, Context, #frag { ty = undefined, directives = Dirs } = Frag) ->
+    frag_sset(EP, Path,
           Frag#frag {
-            directives = directives([Frag | Path], Context, Dirs)
+            directives = directives(EP, [Frag | Path], Context, Dirs)
            });
-frag(Path, Context, #frag { ty = T, directives = Dirs } = Frag) ->
+frag(EP, Path, Context, #frag { ty = T, directives = Dirs } = Frag) ->
     Ty = graphql_ast:name(T),
-    case graphql_schema:lookup(Ty) of
+    case graphql_schema:lookup(EP, Ty) of
         not_found ->
             err([Frag | Path], {type_not_found, Ty});
         TypeSchema ->
-            frag_sset(Path,
+            frag_sset(EP, Path,
                   Frag#frag {
                     schema = TypeSchema,
-                    directives = directives([Frag|Path], Context, Dirs) })
+                    directives = directives(EP, [Frag|Path], Context, Dirs) })
     end.
 
 %% Handle the fields in a fragment by looking at its object type
-frag_sset(Path, #frag { schema = #object_type{ fields = Fields }} = F) ->
-    sset([F | Path], F, Fields);
-frag_sset(Path, #frag { schema = #interface_type{ fields = Fields }} = F) ->
-    sset([F | Path], F, Fields);
-frag_sset(Path, #frag { schema = #union_type{}} = F) ->
+frag_sset(EP, Path, #frag { schema = #object_type{ fields = Fields }} = F) ->
+    sset(EP, [F | Path], F, Fields);
+frag_sset(EP, Path, #frag { schema = #interface_type{ fields = Fields }} = F) ->
+    sset(EP, [F | Path], F, Fields);
+frag_sset(EP, Path, #frag { schema = #union_type{}} = F) ->
     %% Unions are always on the empty field set
     %% This should return quickly, but is here for consistency
-    sset([F | Path], F, #{}).
+    sset(EP, [F | Path], F, #{}).
 
 %% -- OPERATIONS -----------------------------------
 
@@ -154,35 +154,35 @@ operation_context({mutation, _}) -> mutation;
 operation_context({subscription, _}) -> subscription.
 
 %% Operations are straightforward congruences: elaborate into the structure
-op(Path, #op { ty = Ty, vardefs = VDefs, directives = Dirs } = Op) ->
-    RootSchema = root(Path, Op),
-    case graphql_schema:lookup(RootSchema) of
+op(EP, Path, #op { ty = Ty, vardefs = VDefs, directives = Dirs } = Op) ->
+    RootSchema = root(EP, Path, Op),
+    case graphql_schema:lookup(EP, RootSchema) of
         not_found ->
             err([Op | Path], {type_not_found, RootSchema});
         #object_type{ fields = Fields } = Obj ->
             OperationType = operation_context(Ty),
-            sset([Op | Path],
+            sset(EP, [Op | Path],
                  Op#op{ schema = Obj,
-                        directives = directives(
-                                       [Op | Path], OperationType, Dirs),
-                        vardefs = var_defs([Op | Path], VDefs) }, Fields)
+                        directives = directives(EP,
+                                                [Op | Path], OperationType, Dirs),
+                        vardefs = var_defs(EP, [Op | Path], VDefs) }, Fields)
     end.
 
 %% Handle a list of vardefs by elaboration of their types
-var_defs(Path, VDefs) ->
-    [case input_type(V#vardef.ty) of
+var_defs(EP, Path, VDefs) ->
+    [case input_type(EP, V#vardef.ty) of
          {ok, Ty} -> V#vardef { ty = Ty };
          {error, not_found} -> err(Path, {type_not_found, graphql_ast:id(V)});
          {error, {invalid_input_type, T}} -> err(Path, {not_input_type, T})
      end || V <- VDefs].
 
 %% -- DIRECTIVES -----------------------------------
-directives(Path, Context, Ds) ->
+directives(EP, Path, Context, Ds) ->
     NamedDirectives = [{graphql_ast:name(ID), D} 
                        || #directive { id = ID } = D <- Ds],
     case graphql_ast:uniq(NamedDirectives) of
         ok ->
-            try [directive(Path, Context, D) || D <- Ds]
+            try [directive(EP, Path, Context, D) || D <- Ds]
             catch throw:{unknown, Unknown} ->
                     err(Path, {unknown_directive, graphql_ast:id(Unknown)})
             end;
@@ -190,20 +190,20 @@ directives(Path, Context, Ds) ->
             err(Path, {directives_not_unique, X})
     end.
 
-directive(Path, Context, #directive{ id = ID, args = Args } = D) ->
+directive(EP, Path, Context, #directive{ id = ID, args = Args } = D) ->
     Schema = #directive_type { args = SArgs,
                                locations = Locations } =
         case graphql_ast:name(ID) of
             <<"include">> ->
-                graphql_builtins:directive_schema(include);
+                graphql_builtins:directive_schema(EP, include);
             <<"skip">> ->
-                graphql_builtins:directive_schema(skip);
+                graphql_builtins:directive_schema(EP, skip);
             _Name ->
                 throw({unknown, D})
         end,
     case lists:member(Context, Locations) of
         true ->
-            D#directive { args = field_args([D | Path], Args, SArgs),
+            D#directive { args = field_args(EP, [D | Path], Args, SArgs),
                           schema = Schema };
         false ->
             err(Path, {invalid_directive_location, graphql_ast:name(ID), Context})
@@ -213,22 +213,22 @@ directive(Path, Context, #directive{ id = ID, args = Args } = D) ->
 
 %% A selection set is handled by recursing into the fragment or operation,
 %% then process each field inside the selection set of that operation.
-sset(Path, #frag { schema = OType, selection_set = SSet} = F, Fields) ->
-    F#frag{ selection_set = [field(Path, OType, S, Fields) || S <- SSet] };
-sset(Path, #op{ schema = OType, selection_set = SSet} = O, Fields) ->
-    O#op{ selection_set = [field(Path, OType, S, Fields) || S <- SSet]}.
+sset(EP, Path, #frag { schema = OType, selection_set = SSet} = F, Fields) ->
+    F#frag{ selection_set = [field(EP, Path, OType, S, Fields) || S <- SSet] };
+sset(EP, Path, #op{ schema = OType, selection_set = SSet} = O, Fields) ->
+    O#op{ selection_set = [field(EP, Path, OType, S, Fields) || S <- SSet]}.
 
 %% Fields are either fragment spreads, inline fragments, or fields. Recurse and
 %% elaborate on the congruence in a straightforward way.
-field(Path, _OType, #frag_spread { directives = Dirs } = FragSpread, _Fields) ->
-    ElabDirs = directives([FragSpread | Path], fragment_spread, Dirs),
+field(EP, Path, _OType, #frag_spread { directives = Dirs } = FragSpread, _Fields) ->
+    ElabDirs = directives(EP, [FragSpread | Path], fragment_spread, Dirs),
     FragSpread#frag_spread { directives = ElabDirs };
 %% Inline fragments are elaborated the same way as fragments
-field(Path, OType, #frag { id = '...' } = Frag, _Fields) ->
-    frag(Path, inline_fragment, Frag#frag { schema = OType });
-field(Path, _OType, #field { id = ID, args = Args, selection_set = SSet, directives = Dirs } = F, Fields) ->
+field(EP, Path, OType, #frag { id = '...' } = Frag, _Fields) ->
+    frag(EP, Path, inline_fragment, Frag#frag { schema = OType });
+field(EP, Path, _OType, #field { id = ID, args = Args, selection_set = SSet, directives = Dirs } = F, Fields) ->
     Name = graphql_ast:name(ID),
-    ElabDirs = directives([F | Path], field, Dirs),
+    ElabDirs = directives(EP, [F | Path], field, Dirs),
     case maps:get(Name, Fields, not_found) of
         %% Elaborate for the introspection system. __typename is always a valid name
         %% since it refers to the type of the object
@@ -238,42 +238,42 @@ field(Path, _OType, #field { id = ID, args = Args, selection_set = SSet, directi
         not_found ->
             err([F|Path], unknown_field);
         #schema_field{ ty = Ty, args = SArgs } = SF ->
-            {ok, Type} = output_type(Ty),
-            SSet2 = field_sset([F|Path], Type, SSet),
+            {ok, Type} = output_type(EP, Ty),
+            SSet2 = field_sset(EP, [F|Path], Type, SSet),
             F#field {
-                args = field_args([F | Path], Args, SArgs),
+                args = field_args(EP, [F | Path], Args, SArgs),
                 schema = SF#schema_field{ ty = Type },
                 directives = ElabDirs,
                 selection_set = SSet2 }
      end.
 
-field_args(Path, Args, SArgs) ->
-    [field_arg(Path, K, V, SArgs) || {K,V} <- Args].
+field_args(EP, Path, Args, SArgs) ->
+    [field_arg(EP, Path, K, V, SArgs) || {K,V} <- Args].
 
-field_arg(Path, K, V, SArgs) ->
+field_arg(EP, Path, K, V, SArgs) ->
     N = graphql_ast:name(K),
     case maps:get(N, SArgs, not_found) of
         not_found ->
             err(Path, {unknown_argument, N});
         #schema_arg{ ty = Ty } ->
-            {ok, ElabTy} = input_type(Ty),
+            {ok, ElabTy} = input_type(EP, Ty),
             {K, #{ type => ElabTy, value => V}}
     end.
 
 %% Evaluate the Type of a field and its selection set in order to
 %% elaborate the selection set of fields according to the type given
-field_sset(Path, {non_null, Obj}, SSet)                            -> field_sset(Path, Obj, SSet);
-field_sset(Path, {list, Obj}, SSet)                                -> field_sset(Path, Obj, SSet);
-field_sset(Path, not_found, _SSet)                                 -> err(Path, unknown_field);
-field_sset(Path, #scalar_type{}, [_|_])                            -> err(Path, selection_on_scalar);
-field_sset(Path, #scalar_type{}, SSet)                             -> [field(Path, undefined, S, #{}) || S <- SSet];
-field_sset(Path, #object_type{}, [])                               -> err(Path, fieldless_object);
-field_sset(Path, #object_type{ fields = Fields } = OType, SSet)    -> [field(Path, OType, S, Fields) || S <- SSet];
-field_sset(Path, #interface_type{}, [])                            -> err(Path, fieldless_interface);
-field_sset(Path, #interface_type{ fields = Fields } = IType, SSet) -> [field(Path, IType, S, Fields) || S <- SSet];
-field_sset(Path, #union_type{} = UType, SSet)                      -> [field(Path, UType, S, #{}) || S <- SSet];
-field_sset(_Path, #enum_type{}, [])                                -> [];
-field_sset(Path, #enum_type{}, _SSet)                              -> err(Path, selection_on_enum).
+field_sset( EP, Path, {non_null, Obj}, SSet)                            -> field_sset(EP, Path, Obj, SSet);
+field_sset( EP, Path, {list, Obj}, SSet)                                -> field_sset(EP, Path, Obj, SSet);
+field_sset(_EP, Path, not_found, _SSet)                                 -> err(Path, unknown_field);
+field_sset(_EP, Path, #scalar_type{}, [_|_])                            -> err(Path, selection_on_scalar);
+field_sset( EP, Path, #scalar_type{}, SSet)                             -> [field(EP, Path, undefined, S, #{}) || S <- SSet];
+field_sset(_EP, Path, #object_type{}, [])                               -> err(Path, fieldless_object);
+field_sset( EP, Path, #object_type{ fields = Fields } = OType, SSet)    -> [field(EP, Path, OType, S, Fields) || S <- SSet];
+field_sset(_EP, Path, #interface_type{}, [])                            -> err(Path, fieldless_interface);
+field_sset( EP, Path, #interface_type{ fields = Fields } = IType, SSet) -> [field(EP, Path, IType, S, Fields) || S <- SSet];
+field_sset( EP, Path, #union_type{} = UType, SSet)                      -> [field(EP, Path, UType, S, #{}) || S <- SSet];
+field_sset(_EP,_Path, #enum_type{}, [])                                -> [];
+field_sset(_EP, Path, #enum_type{}, _SSet)                              -> err(Path, selection_on_enum).
 
 %% -- ERROR HANDLING ------------------------------------------
 -spec err(term(), term()) -> no_return().

--- a/src/graphql_introspection.erl
+++ b/src/graphql_introspection.erl
@@ -3,7 +3,7 @@
 -include("graphql_schema.hrl").
 -include_lib("graphql/include/graphql.hrl").
 
--export([inject/0, augment_root/1]).
+-export([inject/1, augment_root/2]).
 
 -export([execute/4]).
 
@@ -17,11 +17,11 @@
     subscription_type/3
 ]).
 
--spec augment_root(QueryObj) -> ok
+-spec augment_root(graphql_schema:endpoint_context(), QueryObj) -> ok
   when QueryObj :: binary().
 
-augment_root(QName) ->
-    #object_type{ fields = Fields } = Obj = graphql_schema:get(QName),
+augment_root(EP, QName) ->
+    #object_type{ fields = Fields } = Obj = graphql_schema:get(EP, QName),
     Schema = #schema_field {
                 ty = {non_null, <<"__Schema">>},
                 description = <<"The introspection schema">>,
@@ -40,63 +40,63 @@ augment_root(QName) ->
                                              <<"__schema">> => Schema,
                                              <<"__type">> => Type
                                             }},
-    true = graphql_schema:insert(Augmented, #{}),
+    true = graphql_schema:insert(EP, Augmented, #{}),
     ok.
 
-schema_resolver(_Ctx, none, #{}) ->
+schema_resolver(_Ctx = #{endpoint_context := EP}, none, #{}) ->
     {ok, #{ <<"directives">> =>
-                [directive(include),
-                 directive(skip)]}}.
+                [directive(EP, include),
+                 directive(EP, skip)]}}.
 
-type_resolver(_Ctx, none, #{ <<"name">> := N }) ->
-    case graphql_schema:lookup(N) of
+type_resolver(_Ctx = #{endpoint_context := EP}, none, #{ <<"name">> := N }) ->
+    case graphql_schema:lookup(EP, N) of
         not_found -> {ok, null};
-        Ty -> render_type(Ty)
+        Ty -> render_type(EP, Ty)
     end.
 
-query_type(_Ctx, _Obj, _) ->
-    #root_schema{ query = QType } = graphql_schema:get('ROOT'),
-    render_type(QType).
+query_type(_Ctx = #{endpoint_context := EP}, _Obj, _) ->
+    #root_schema{ query = QType } = graphql_schema:get(EP, 'ROOT'),
+    render_type(EP, QType).
 
-mutation_type(_Ctx, _Obj, _) ->
-    #root_schema { mutation = MType } = graphql_schema:get('ROOT'),
+mutation_type(_Ctx = #{endpoint_context := EP}, _Obj, _) ->
+    #root_schema { mutation = MType } = graphql_schema:get(EP, 'ROOT'),
     case MType of
         undefined -> {ok, null};
-        MT -> render_type(MT)
+        MT -> render_type(EP, MT)
     end.
 
-subscription_type(_Ctx, _Obj, _) ->
-    #root_schema { subscription = SType } = graphql_schema:get('ROOT'),
+subscription_type(_Ctx = #{endpoint_context := EP}, _Obj, _) ->
+    #root_schema { subscription = SType } = graphql_schema:get(EP, 'ROOT'),
     case SType of
         undefined -> {ok, null};
-        ST -> render_type(ST)
+        ST -> render_type(EP, ST)
     end.
 
-schema_types(_Ctx, _Obj, _Args) ->
+schema_types(_Ctx = #{endpoint_context := EP}, _Obj, _Args) ->
     Pass = fun
         (#root_schema{}) -> false;
         (_) -> true
     end,
-    Types = [X || X <- graphql_schema:all(), Pass(X)],
-    {ok, [render_type(Ty) || Ty <- Types]}.
+    Types = [X || X <- graphql_schema:all(EP), Pass(X)],
+    {ok, [render_type(EP, Ty) || Ty <- Types]}.
 
 %% Main renderer. Calls out to the subsets needed
-render_type(Name) when is_binary(Name) ->
-    case graphql_schema:lookup(Name) of
+render_type(EP, Name) when is_binary(Name) ->
+    case graphql_schema:lookup(EP, Name) of
         not_found ->
            throw({not_found, Name});
-       Ty -> render_type(Ty)
+       Ty -> render_type(EP, Ty)
     end;
-render_type(Ty) -> {ok, #{
+render_type(EP, Ty) -> {ok, #{
     <<"kind">> => type_kind(Ty),
     <<"name">> => type_name(Ty),
     <<"description">> => type_description(Ty),
-    <<"fields">> => type_fields(Ty),
-    <<"interfaces">> => type_interfaces(Ty),
-    <<"possibleTypes">> => type_possibilities(Ty),
+    <<"fields">> => type_fields(EP, Ty),
+    <<"interfaces">> => type_interfaces(EP, Ty),
+    <<"possibleTypes">> => type_possibilities(EP, Ty),
     <<"enumValues">> => type_enum_values(Ty),
-    <<"inputFields">> => type_input_fields(Ty),
-    <<"ofType">> => type_unwrap(Ty) }}.
+    <<"inputFields">> => type_input_fields(EP, Ty),
+    <<"ofType">> => type_unwrap(EP, Ty) }}.
 
 type_kind(#scalar_type{}) -> <<"SCALAR">>;
 type_kind(#object_type {}) -> <<"OBJECT">>;
@@ -123,15 +123,15 @@ type_description(#enum_type{ description = D}) -> D;
 type_description(#scalar_type{ description = D}) -> D;
 type_description(_) -> null.
 
-type_interfaces(#object_type{ interfaces = IFs }) ->
-    ?LAZY({ok, [render_type(Ty) || Ty <- IFs]});
-type_interfaces(_) -> null.
+type_interfaces(EP, #object_type{ interfaces = IFs }) ->
+    ?LAZY({ok, [render_type(EP, Ty) || Ty <- IFs]});
+type_interfaces(_EP, _) -> null.
 
-type_possibilities(#interface_type { id = ID }) ->
-    ?LAZY(interface_implementors(ID));
-type_possibilities(#union_type { types = Types }) ->
-    ?LAZY({ok, [render_type(Ty) || Ty <- Types]});
-type_possibilities(_) -> null.
+type_possibilities(EP, #interface_type { id = ID }) ->
+    ?LAZY(interface_implementors(EP, ID));
+type_possibilities(EP, #union_type { types = Types }) ->
+    ?LAZY({ok, [render_type(EP, Ty) || Ty <- Types]});
+type_possibilities(_EP, _) -> null.
 
 type_enum_values(#enum_type { values = VMap }) ->
     [begin
@@ -140,25 +140,25 @@ type_enum_values(#enum_type { values = VMap }) ->
      end || V <- maps:to_list(VMap)];
 type_enum_values(_) -> null.
 
-type_unwrap({list, Ty}) -> {ok, U} = render_type(Ty), U;
-type_unwrap({non_null, Ty}) -> {ok, U} = render_type(Ty), U;
-type_unwrap(_) -> null.
+type_unwrap(EP, {list, Ty}) -> {ok, U} = render_type(EP, Ty), U;
+type_unwrap(EP, {non_null, Ty}) -> {ok, U} = render_type(EP, Ty), U;
+type_unwrap(_EP, _) -> null.
 
-type_input_fields(#input_object_type{ fields = FS }) ->
-    ?LAZY({ok, [render_input_value(F) || F <- maps:to_list(FS)]});
-type_input_fields(_) -> null.
+type_input_fields(EP, #input_object_type{ fields = FS }) ->
+    ?LAZY({ok, [render_input_value(EP, F) || F <- maps:to_list(FS)]});
+type_input_fields(_EP, _) -> null.
 
-type_fields(#object_type { fields = FS }) ->
-    ?LAZY({ok, [render_field(F) || F <- maps:to_list(FS), interesting_field(F)]});
-type_fields(#interface_type { fields = FS }) ->
-    ?LAZY({ok, [render_field(F) || F <- maps:to_list(FS), interesting_field(F)]});
-type_fields(_) -> null.
+type_fields(EP, #object_type { fields = FS }) ->
+    ?LAZY({ok, [render_field(EP, F) || F <- maps:to_list(FS), interesting_field(F)]});
+type_fields(EP, #interface_type { fields = FS }) ->
+    ?LAZY({ok, [render_field(EP, F) || F <- maps:to_list(FS), interesting_field(F)]});
+type_fields(_EP, _) -> null.
 
 interesting_field({<<"__schema">>, #schema_field {}}) -> false;
 interesting_field({<<"__type">>, #schema_field{}}) -> false;
 interesting_field({_, _}) -> true.
 
-render_field({Name, #schema_field {
+render_field(EP, {Name, #schema_field {
                        description = Desc,
                        args = Args,
                        ty = Ty,
@@ -168,26 +168,26 @@ render_field({Name, #schema_field {
     {ok, #{
         <<"name">> => Name,
         <<"description">> => Desc,
-        <<"args">> => ?LAZY({ok, [render_input_value(IV) || IV <- maps:to_list(Args)]}),
-        <<"type">> => ?LAZY(render_type(Ty)),
+        <<"args">> => ?LAZY({ok, [render_input_value(EP, IV) || IV <- maps:to_list(Args)]}),
+        <<"type">> => ?LAZY(render_type(EP, Ty)),
         <<"isDeprecated">> => IsDeprecated,
         <<"deprecationReason">> => DeprecationReason
       }}.
 
-render_input_value({K, #schema_arg { ty = Ty, description = Desc }}) ->
+render_input_value(EP, {K, #schema_arg { ty = Ty, description = Desc }}) ->
     {ok, #{
         <<"name">> => K,
         <<"description">> => Desc,
-        <<"type">> => ?LAZY(render_type(Ty)),
+        <<"type">> => ?LAZY(render_type(EP, Ty)),
         <<"defaultValue">> => null
     }}.
 
-interface_implementors(ID) ->
+interface_implementors(EP, ID) ->
     Pass = fun
         (#object_type { interfaces = IFs }) -> lists:member(ID, IFs);
         (_) -> false
     end,
-    {ok, [render_type(Ty) || Ty <- graphql_schema:all(), Pass(Ty)]}.
+    {ok, [render_type(EP, Ty) || Ty <- graphql_schema:all(EP), Pass(Ty)]}.
 
 render_enum_value({_Value, #enum_value{
                               val = Key,
@@ -208,8 +208,8 @@ render_deprecation(Reason) when is_binary(Reason) ->
     {true, Reason}.
 
 %% -- SCHEMA DEFINITION -------------------------------------------------------
--spec inject() -> ok.
-inject() ->
+-spec inject(graphql_schema:endpoint_context()) -> ok.
+inject(EP) ->
     Schema = {object, #{
                 id => '__Schema',
                 resolve_module => ?MODULE,
@@ -401,19 +401,19 @@ inject() ->
                              'FRAGMENT_SPREAD' => #{ value => 5, description => "Fragment spread" },
                              'INLINE_FRAGMENT' => #{ value => 6, description => "Inline fragments" }
                             }}},
-    ok = graphql:insert_schema_definition(DirectiveLocation),
-    ok = graphql:insert_schema_definition(Directive),
-    ok = graphql:insert_schema_definition(TypeKind),
-    ok = graphql:insert_schema_definition(Enum),
-    ok = graphql:insert_schema_definition(InputValue),
-    ok = graphql:insert_schema_definition(Field),
-    ok = graphql:insert_schema_definition(Type),
-    ok = graphql:insert_schema_definition(Schema),
+    ok = graphql:ep_insert_schema_definition(EP, DirectiveLocation),
+    ok = graphql:ep_insert_schema_definition(EP, Directive),
+    ok = graphql:ep_insert_schema_definition(EP, TypeKind),
+    ok = graphql:ep_insert_schema_definition(EP, Enum),
+    ok = graphql:ep_insert_schema_definition(EP, InputValue),
+    ok = graphql:ep_insert_schema_definition(EP, Field),
+    ok = graphql:ep_insert_schema_definition(EP, Type),
+    ok = graphql:ep_insert_schema_definition(EP, Schema),
     ok.
 
 %% @todo: Look up the directive in the schema and then use that lookup as a way to render the
 %% following part. Most notably, locations can be mapped from the directive type.
-directive(Kind) ->
+directive(EP, Kind) ->
     {Name, Desc} =
         case Kind of
             include ->
@@ -423,7 +423,7 @@ directive(Kind) ->
                 {<<"skip">>,
                  <<"exclude a selection on a conditional variable">>}
         end,
-    {ok, Bool} = render_type(<<"Bool">>),
+    {ok, Bool} = render_type(EP, <<"Bool">>),
 
     #{
        <<"name">> => Name,

--- a/src/graphql_schema.erl
+++ b/src/graphql_schema.erl
@@ -5,15 +5,16 @@
 -include("graphql_schema.hrl").
 -include("graphql_internal.hrl").
 
--export([start_link/0, reset/0]).
+-export([start_link/1, reset/0, reset/1]).
 -export([
-         all/0,
-         insert/1, insert/2,
-         load/1,
-         get/1,
-         lookup/1,
-         lookup_enum_type/1,
-         lookup_interface_implementors/1
+         get_endpoint/1,
+         all/1,
+         insert/2, insert/3,
+         load/2,
+         get/2,
+         lookup/2,
+         lookup_enum_type/2,
+         lookup_interface_implementors/2
         ]).
 -export([resolve_root_type/2]).
 
@@ -23,33 +24,59 @@
 -export([init/1, handle_call/3, handle_cast/2, terminate/2, handle_info/2,
     code_change/3]).
 
--define(ENUMS, graphql_schema_enums).
--define(OBJECTS, graphql_schema_objects).
+%% Miscellaneous
+-record(endpoint_context, {
+    pid       :: pid(),
+    enumTab   :: ets:tid(),
+    objectTab :: ets:tid()
+}).
 
--record(state, {}).
+
+-record(state, {
+    endpoint_context :: #endpoint_context{}
+}).
 
 %% -- API ----------------------------
--spec start_link() -> any().
-start_link() ->
-    Res = gen_server:start_link({local, ?MODULE}, ?MODULE, [], []),
-    reset(),
+
+-type server_ref() :: pid() | atom().
+-type endpoint_context() :: #endpoint_context{}.
+
+
+-spec start_link(atom()) -> any().
+start_link(EPName) ->
+    Res = {ok, Pid} =
+          case EPName of
+              undefined -> gen_server:start_link(?MODULE, [], []);
+              _Other -> gen_server:start_link({local, EPName}, ?MODULE, [], [])
+          end,
+    EP = get_endpoint(Pid),
+    reset(EP),
     Res.
 
 -spec reset() -> ok.
-reset() ->
-    ok = gen_server:call(?MODULE, reset),
-    ok = graphql_introspection:inject(),
-    ok = graphql_builtins:standard_types_inject(),
+reset() -> reset(graphql:default_endpoint()).
+
+-spec reset(endpoint_context()) -> ok.
+reset(EP = #endpoint_context{pid=Pid}) ->
+    ok = gen_server:call(Pid, reset),
+    ok = graphql_introspection:inject(EP),
+    ok = graphql_builtins:standard_types_inject(EP),
     ok.
 
--spec insert(any()) -> true.
-insert(S) -> insert(S, #{ canonicalize => true }).
 
--spec insert(any(), any()) -> true | false.
-insert(S, #{ canonicalize := true }) ->
+
+-spec get_endpoint(server_ref()) -> endpoint_context().
+get_endpoint(P) ->
+    gen_server:call(P, get_endpoint_context).
+
+-spec insert(endpoint_context(), any()) -> true.
+insert(EP, S) -> insert(EP, S, #{ canonicalize => true }).
+
+-spec insert(endpoint_context(), any(), any()) -> true | false.
+insert(_EP = #endpoint_context{pid=Pid}, S, #{ canonicalize := true }) ->
     try graphql_schema_canonicalize:x(S) of
         Rec ->
-            case gen_server:call(?MODULE, {insert, Rec}) of
+            case gen_server:call(Pid, {insert, Rec}) of
                 true -> ok;
                 false ->
                     Identify = fun({_, #{ id := ID }}) -> ID end,
@@ -62,45 +89,45 @@ insert(S, #{ canonicalize := true }) ->
               [{Class,Reason}, erlang:get_stacktrace()]),
             {error, {schema_canonicalize, {Class, Reason}}}
     end;
-insert(S, #{}) ->
-    gen_server:call(?MODULE, {insert, S}).
+insert(_EP = #endpoint_context{pid=Pid}, S, #{}) ->
+    gen_server:call(Pid, {insert, S}).
 
 
--spec load(any()) -> ok | {error, Reason}
+-spec load(endpoint_context(), any()) -> ok | {error, Reason}
   when Reason :: term().
-load(S) ->
+load(EP = #endpoint_context{pid=Pid}, S) ->
     try graphql_schema_canonicalize:x(S) of
         #root_schema { query = Q } = Rec ->
-            ok = graphql_introspection:augment_root(Q),
-            insert_new_(Rec);
+            ok = graphql_introspection:augment_root(EP, Q),
+            insert_new_(Pid, Rec);
         Rec ->
-            insert_new_(Rec)
+            insert_new_(Pid, Rec)
     catch
         Class:Reason ->
             {error, {schema_canonicalize, {Class, Reason}}}
     end.
 
-insert_new_(Rec) ->
-    case gen_server:call(?MODULE, {insert_new, Rec}) of
+insert_new_(Pid, Rec) ->
+    case gen_server:call(Pid, {insert_new, Rec}) of
         true -> ok;
         false -> {error, already_exists, id(Rec)}
     end.
 
--spec all() -> [any()].
-all() ->
-    ets:match_object(?OBJECTS, '_').
+-spec all(endpoint_context()) -> [any()].
+all(#endpoint_context{objectTab = Tab}) ->
+    ets:match_object(Tab, '_').
 
--spec get(binary() | 'ROOT') -> schema_object().
-get(ID) ->
-    case ets:lookup(?OBJECTS, ID) of
+-spec get(endpoint_context(), binary() | 'ROOT') -> schema_object().
+get(#endpoint_context{objectTab = Tab}, ID) ->
+    case ets:lookup(Tab, ID) of
        [S] -> S;
        _ -> exit(schema_not_found)
     end.
 
--spec lookup_enum_type(binary()) -> binary() | not_found.
-lookup_enum_type(EnumValue) ->
-    try ets:lookup_element(?ENUMS, EnumValue, 3) of
-        Ty -> ?MODULE:get(Ty)
+-spec lookup_enum_type(endpoint_context(), binary()) -> binary() | not_found.
+lookup_enum_type(EP=#endpoint_context{enumTab = Tab}, EnumValue) ->
+    try ets:lookup_element(Tab, EnumValue, 3) of
+        Ty -> ?MODULE:get(EP, Ty)
     catch
         error:badarg ->
             not_found
@@ -112,17 +139,17 @@ lookup_enum_type(EnumValue) ->
 %%
 %% However, in the spirit of getting something up and running, we start
 %% with QLC in order to make a working system.
--spec lookup_interface_implementors(binary()) -> [binary()].
-lookup_interface_implementors(IFaceID) ->
+-spec lookup_interface_implementors(endpoint_context(), binary()) -> [binary()].
+lookup_interface_implementors(#endpoint_context{objectTab = Tab}, IFaceID) ->
     QH = qlc:q([Obj#object_type.id
-                || Obj <- ets:table(?OBJECTS),
+                || Obj <- ets:table(Tab),
                    element(1, Obj) == object_type,
                    lists:member(IFaceID, Obj#object_type.interfaces)]),
     qlc:e(QH).
 
--spec lookup(binary() | 'ROOT') -> schema_object() | not_found.
-lookup(ID) ->
-    case ets:lookup(?OBJECTS, ID) of
+-spec lookup(endpoint_context(), binary() | 'ROOT') -> schema_object() | not_found.
+lookup(#endpoint_context{objectTab = Tab}, ID) ->
+    case ets:lookup(Tab, ID) of
        [S] -> S;
        _ -> not_found
     end.
@@ -145,13 +172,17 @@ id(#input_object_type{ id = ID }) -> ID.
 
 -spec init([]) -> {ok, #state{}}.
 init([]) ->
-    _Tab1 = ets:new(?ENUMS,
-         [named_table, protected, {read_concurrency, true}, set,
-           {keypos, 1}]),
-    _Tab = ets:new(?OBJECTS,
-        [named_table, protected, {read_concurrency, true}, set,
-         {keypos, #object_type.id}]),
-    {ok, #state{}}.
+    EndpointContext = #endpoint_context{
+        pid = self(),
+        enumTab = ets:new(graphql_enum_table,
+                          [protected, {read_concurrency, true}, set,
+                           {keypos, 1}]),
+
+        objectTab = ets:new(graphql_object_table,
+                            [protected, {read_concurrency, true}, set,
+                             {keypos, #object_type.id}])
+    },
+    {ok, #state{endpoint_context = EndpointContext}}.
 
 -spec handle_cast(any(), S) -> {noreply, S}
   when S :: #state{}.
@@ -161,8 +192,10 @@ handle_cast(_Msg, State) -> {noreply, State}.
   when
     S :: #state{},
     M :: term().
-handle_call({insert, X}, _From, State) ->
-    case determine_table(X) of
+handle_call(get_endpoint_context, _From, State=#state{endpoint_context = EP}) ->
+    {reply, EP, State};
+handle_call({insert, X}, _From, State=#state{endpoint_context = EP}) ->
+    case determine_table(EP, X) of
         {error, unknown} ->
             {reply, {error, {schema, X}}, State};
         {enum, Tab, Enum} ->
@@ -172,8 +205,8 @@ handle_call({insert, X}, _From, State) ->
         Tab ->
             {reply, ets:insert(Tab, X), State}
     end;
-handle_call({insert_new, X}, _From, State) ->
-    case determine_table(X) of
+handle_call({insert_new, X}, _From, State=#state{endpoint_context = EP}) ->
+    case determine_table(EP, X) of
         {error, unknown} ->
             {reply, {error, {schema, X}}, State};
         {enum, Tab, Enum} ->
@@ -187,8 +220,8 @@ handle_call({insert_new, X}, _From, State) ->
         Tab ->
             {reply, ets:insert_new(Tab, X), State}
     end;
-handle_call(reset, _From, State) ->
-    true = ets:delete_all_objects(?OBJECTS),
+handle_call(reset, _From, State = #state{endpoint_context = #endpoint_context{objectTab = Tab}}) ->
+    true = ets:delete_all_objects(Tab),
     {reply, ok, State};
 handle_call(_Msg, _From, State) ->
     {reply, {error, unknown_call}, State}.
@@ -207,14 +240,14 @@ code_change(_OldVsn, State, _Aux) -> {ok, State}.
 %% -- INTERNAL FUNCTIONS -------------------------
 
 %% determine_table/1 figures out the table an object belongs to
-determine_table(#root_schema{}) -> ?OBJECTS;
-determine_table(#object_type{}) -> ?OBJECTS;
-determine_table(#enum_type{}) -> {enum, ?OBJECTS, ?ENUMS};
-determine_table(#interface_type{}) -> ?OBJECTS;
-determine_table(#scalar_type{}) -> ?OBJECTS;
-determine_table(#input_object_type{}) -> ?OBJECTS;
-determine_table(#union_type{}) -> ?OBJECTS;
-determine_table(_) -> {error, unknown}.
+determine_table(#endpoint_context{objectTab = Tab}, #root_schema{}) -> Tab;
+determine_table(#endpoint_context{objectTab = Tab}, #object_type{}) -> Tab;
+determine_table(#endpoint_context{objectTab = ObjectTab, enumTab = EnumTab}, #enum_type{}) -> {enum, ObjectTab, EnumTab};
+determine_table(#endpoint_context{objectTab = Tab}, #interface_type{}) -> Tab;
+determine_table(#endpoint_context{objectTab = Tab}, #scalar_type{}) -> Tab;
+determine_table(#endpoint_context{objectTab = Tab}, #input_object_type{}) -> Tab;
+determine_table(#endpoint_context{objectTab = Tab}, #union_type{}) -> Tab;
+determine_table(_, _) -> {error, unknown}.
 
 %% insert enum values
 insert_enum(Tab, #enum_type { id = ID, values = VMap }) ->

--- a/src/graphql_schema.hrl
+++ b/src/graphql_schema.hrl
@@ -15,7 +15,7 @@
 -type location() :: query | mutation | field
                   | fragment_definition | fragment_spread | inline_fragment.
 
--type resolver() :: fun ((ctx, term(), resolver_args()) -> term()).
+-type resolver() :: fun ((ctx(), term(), resolver_args()) -> term()).
 
 -record(enum_value,
         { val :: binary(),

--- a/src/graphql_sup.erl
+++ b/src/graphql_sup.erl
@@ -11,13 +11,14 @@
 -type start_link_err() :: {already_started, pid()} | shutdown | term().
 -type start_link_ret() :: {ok, pid()} | ignore | {error, start_link_err()}.
 
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
-
 -spec start_link() -> start_link_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 %% @private
 init([]) ->
-    SchemaMgr = ?CHILD(graphql_schema, worker),
+    DefaultEndpoint = graphql_default_endpoint,
+    SchemaMgr = #{id => graphql_schema,
+                  start => {graphql_schema, start_link, [DefaultEndpoint]}
+    },
     {ok, {{one_for_all, 5, 3600}, [SchemaMgr]}}.


### PR DESCRIPTION
I wanted to see how far I could get with this, and I managed to steamroll through the whole thing without getting stuck.  It passes existing tests, but still needs new tests to hit the new APIs better.  Also, the new `ep_` and `p_` APIs could use a review.  

- Multiple endpoints may now run independently each with their own schema process.
- Global context has been replaced with `endpoint_context` type containing schema PID and ets tables.
- New API in `graphql` with `ep_` prefix (ex `ep_execute()`).  These take an `endpoint_context`.
- New API in `graphql` with `p_` prefix (ex `p_execute()`).  These take a schema PID/atom.  This is most useful when you have a named schema process that can be
referred to by its name atom.
- Existing API wraps the `ep_` API and uses the named schema process `graphql_default_endpoint`
- `endpoint_context` is passed inside `Ctx` maps.  The variable `EP` is added when `endpoint_context` is needed but no `Ctx` is available.
- ct tests pass
- addresses issue #91