### PR TITLE
Fix #164 - Alter block strings to use """ over `

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ the compatibility issues you are likely to encounter.
 
 ## [Unreleased]
 
+### NONCOMPATIBLE CHANGES
+- Multiline quotes are now """quoted""" rather than \`quoted\` to
+  match the GraphQL Jun2018 specification.
+
 ### Fix
 
 - The `key` field in errors are now an atom so it can be JSON encoded.

--- a/src/graphql_scanner.xrl
+++ b/src/graphql_scanner.xrl
@@ -38,8 +38,8 @@ EscapedUnicode      = u{HexDigit}{HexDigit}{HexDigit}{HexDigit}
 EscapedCharacter    = ["\\\/bfnrt]
 StringCharacter     = ([^\"{_LineTerminator}]|\\{EscapedUnicode}|\\{EscapedCharacter})
 StringValue         = "{StringCharacter}*"
-MultiCharacter      = ([^`]|\\{EscapedUnicode}|\\{EscapedCharacter})
-MultiStringValue    = `{MultiCharacter}*`
+MultiCharacter      = ([^"]|"[^"]|""[^"]|\\{EscapedUnicode}|\\{EscapedCharacter})
+MultiStringValue    = """{MultiCharacter}*"""
 
 Rules.
 
@@ -48,7 +48,7 @@ Rules.
 {IntValue}		   : {token, {int, TokenLine, list_to_integer(TokenChars)}}.
 {FloatValue}	   : {token, {float, TokenLine, list_to_float(TokenChars)}}.
 {StringValue}	   : {token, {bstring, TokenLine, iolist_to_binary(unquote(TokenChars))}}.
-{MultiStringValue} : {token, {bstring, TokenLine, iolist_to_binary(unquote_ms(TokenChars))}}.
+{MultiStringValue} : {token, {bstring, TokenLine, iolist_to_binary(unquote(TokenChars))}}.
 {Name}		       : {token, identifier(TokenChars, TokenLine)}.
 
 Erlang code.
@@ -77,6 +77,3 @@ identifier(ID, TokenLine) -> {name, TokenLine, iolist_to_binary(ID)}.
 
 unquote(Str) ->
     string:strip(Str, both, $").
-
-unquote_ms(Str) ->
-    string:strip(Str, both, $`).

--- a/test/graphql_SUITE_data/test_schema.spec
+++ b/test/graphql_SUITE_data/test_schema.spec
@@ -4,14 +4,14 @@ interface Node {
 
 union Thing = Item | Monster
 
-+description(text: `
-How to represent "colors" in the output`)
++description(text: """
+How to represent "colors" in the output""")
 scalar ColorType
 
-+description(text: `Represents a color in the system`)
++description(text: """Represents a color in the system""")
 scalar Color
 
-+description(text: `How to enter monster stats`)
++description(text: """How to enter monster stats""")
 input StatsInput {
 
 	+description(text: "The attack value of the monster")


### PR DESCRIPTION
This follows the Jun2018 specification rather than our own specification.