### PR TITLE
Add tests for unions

### DIFF
--- a/src/graphql_schema.hrl
+++ b/src/graphql_schema.hrl
@@ -48,7 +48,7 @@
           description :: binary(),
           resolve_type :: mod() | fun ((any()) -> {ok, atom()} | {error, term()}),
           annotations = #{} :: #{ binary() => any() },
-          types :: [binary()]
+          types :: [binary() | {name, non_neg_integer(), binary()}]
         }).
 -type union_type() :: #union_type{}.
 

--- a/test/graphql_SUITE_data/empty_union.spec
+++ b/test/graphql_SUITE_data/empty_union.spec
@@ -1,0 +1,2 @@
+union Foo
+

--- a/test/graphql_SUITE_data/non_unique_union.spec
+++ b/test/graphql_SUITE_data/non_unique_union.spec
@@ -1,0 +1,10 @@
+type Coord {
+    latitude: Float!
+    longitude: Float!
+}
+
+type Geo {
+    hash: String
+}
+
+union Loc = Coord | Geo | Coord


### PR DESCRIPTION
; Test empty unions. These were already correctly rejected by the
  parser which disallows an empty union specification altogether. It
  requires at least one entry.
; Test unions with duplicate names. This is now handled in the Schema
  validator where we check a union for unique references. This ensures
  a union is not going to contain the same name twice.