### PR TITLE
Field directive hook idea

### DIFF
--- a/include/graphql.hrl
+++ b/include/graphql.hrl
@@ -2,7 +2,8 @@
 -record(directive,
         { id :: graphql:name(),
           args = [] :: #{ binary() => term() } | [{any(), any()}],
-          schema :: any()
+          schema :: any(),
+          resolve_module :: atom()
         }).
 
 -define(LAZY(X), {'$lazy', fun() -> X end}).

--- a/test/dungeon.erl
+++ b/test/dungeon.erl
@@ -180,6 +180,7 @@ mapping_rules() ->
        enums => #{ 'Mood' => dungeon_enum, default => graphql_enum_coerce },
        interfaces => #{ default => dungeon_type },
        unions => #{ default => dungeon_type },
+       directives => #{ default => dungeon_directive },
        objects => #{
          'Monster' => dungeon_monster,
          'Item' => dungeon_item,

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -75,6 +75,7 @@ groups() ->
          , nested_field_merge
          , multiple_monsters_and_rooms
          , include_directive
+         , custom_field_directives
          , introspection
          , introspection_with_variable
          , get_operation
@@ -230,6 +231,19 @@ include_directive(Config) ->
              <<"hitpoints">> := 10 }}} =
         run(Config, <<"GoblinQueryDirectivesInline">>, #{ <<"fat">> => true }),
     ok.
+
+custom_field_directives(Config) ->
+    GoblinId = ?config(known_goblin_id_1, Config),
+    #{
+        errors := [
+            #{ key := resolver_error, message := <<"{always_error_directive,<<\"custom directive test\">>}">>}],
+        data := #{
+            <<"goblin">> := #{
+            <<"id">> := GoblinId,
+            <<"inventory">> := null }}
+    } = run(Config, <<"GoblinQueryCustomFieldDirectives">>, #{}),
+    ok.
+
 
 unions(Config) ->
     ct:log("Initial query on the schema"),

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -41,7 +41,7 @@ type Monster implements Node {
   name : String! @private(scope: "memberOf")
   color(colorType: ColorType = "rgb") : Color!
   hitpoints : Int!
-  inventory : [Thing]
+  inventory : [Thing] @alwaysError(reason: "custom directive test")
   hp : Int!
   mood(fail: Bool) : Mood @private
   plushFactor : Float!

--- a/test/dungeon_SUITE_data/query.graphql
+++ b/test/dungeon_SUITE_data/query.graphql
@@ -94,6 +94,13 @@ query GoblinQueryDirectivesInline($id : Id! = "bW9uc3Rlcjox", $fat : Bool!) {
   }
 }
 
+query GoblinQueryCustomFieldDirectives($id : Id! = "bW9uc3Rlcjox") {
+  goblin: monster(id: $id) {
+    id
+    inventory
+  }
+}
+
 query MinGoblin($id : Id! = "bW9uc3Rlcjox", $minAttack : int!) {
   goblin: monster(id: $id) {
     id
@@ -302,6 +309,17 @@ query RollX5($delay: Int){
     rollDeferX2
     rollDeferX3
     rollDeferX5
+  }
+}
+
+query TestFieldDirectiveHook($id: Id!) {
+  monster(id: $id) {
+    inventory {
+      __typename
+      ... on Node {
+        id
+      }
+    }
   }
 }
 

--- a/test/dungeon_directive.erl
+++ b/test/dungeon_directive.erl
@@ -1,0 +1,11 @@
+-module (dungeon_directive).
+
+-include_lib("graphql/include/graphql.hrl").
+
+-export ([execute/6]).
+
+execute(Ctx, Obj, Field, Args, #directive{id = <<"alwaysError">>, args = #{<<"reason">> := Reason}}, Resolver) ->
+    ct:pal("alwaysError directive executed on field ~p at object ~p ", [Field, Obj]),
+    {error, {always_error_directive, Reason}};
+execute(Ctx, Obj, Field, Args, _Directive, Resolver) ->
+    Resolver(Ctx, Obj, Field, Args).

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -35,10 +35,11 @@ execute(Ctx, #monster { id = ID,
             {defer, HPToken};
         <<"hp">> -> {ok, HP};
         <<"inventory">> ->
+            ct:pal("Inventory Context Directives: ~p", [maps:get(field_directives, Ctx)]),
             Data = [dungeon:load(OID) || OID <- Inventory],
             {ok, Data};
         <<"mood">> ->
-            ct:pal("Name Context Directives: ~p", [maps:get(field_directives, Ctx)]),
+            ct:pal("Mood Context Directives: ~p", [maps:get(field_directives, Ctx)]),
             case Args of
                 #{ <<"fail">> := true } ->
                     {ok, <<"INVALIDMOOD">>};


### PR DESCRIPTION
Not happy with the actual implementation here, but I wanted to evaluate the idea.

When executing a field with field directives, you have the option of specifying a middleware-like construct around the field resolution. Each directive can have it's own resolver module, just like resolving objects, scalars, etc.

The directive resolver takes the standard `Ctx, Obj, Field, Args` (right now at least), and then `Directive` and `Resolver`, where directive is the formattet `#directive{}` record and `Resolver` is  the field resolver function that you are expected to call when you have handle your directive-specific logic.
