### PR TITLE
Handle field resolver arity=3 in the canonicalization instead of in the execution

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -451,10 +451,7 @@ resolve_field_value(Ctx, #object_type { id = OID,
         object_type => OID,
         object_directives => format_directives(ODirectives)
     },
-    try (if
-        is_function(Fun, 4) -> Fun(CtxAnnot, Value, Name, Args);
-        is_function(Fun, 3) -> Fun(CtxAnnot, Value, Args)
-    end) of
+    try Fun(CtxAnnot, Value, Name, Args) of
         V -> 
             case handle_resolver_result(V) of
                 wrong ->
@@ -842,7 +839,7 @@ fragments(Frags) ->
 
 %% -- FUNCTION RESOLVERS ---------------------------------
 
-resolver_function(_ObjType, R) when is_function(R, 3) -> R;
+resolver_function(_ObjType, R) when is_function(R, 4) -> R;
 resolver_function(#object_type {
                      id = Id,
                      resolve_module = undefined }, undefined) ->

--- a/src/graphql_schema.hrl
+++ b/src/graphql_schema.hrl
@@ -17,7 +17,7 @@
         | 'SCALAR' | 'OBJECT' | 'FIELD_DEFINITION' | 'ARGUMENT_DEFINITION' | 'INTERFACE'
         | 'UNION' | 'ENUM' | 'ENUM_VALUE' | 'INPUT_OBJECT' | 'INPUT_FIELD_DEFINITION'.
 
--type resolver() :: fun ((ctx, term(), resolver_args()) -> term()).
+-type resolver() :: fun ((ctx, term(), binary(), resolver_args()) -> term()).
 
 -record(directive_type,
         { id :: binary(),

--- a/src/graphql_schema_canonicalize.erl
+++ b/src/graphql_schema_canonicalize.erl
@@ -147,9 +147,14 @@ non_null(Ty) ->
         _Otherwise -> list_to_binary(Ty)
     end.
 
-c_field_val_resolve(#{ resolve := R}) when is_function(R, 3) -> R;
-c_field_val_resolve(#{ resolve := R}) when is_function(R) -> exit(wrong_resolver_arity);
-c_field_val_resolve(_) -> undefined.
+c_field_val_resolve(#{ resolve := R }) when is_function(R, 3) ->
+    fun (Ctx, Obj, _FieldName, Args) -> R(Ctx, Obj, Args) end;
+c_field_val_resolve(#{ resolve := R }) when is_function(R, 4) ->
+    R;
+c_field_val_resolve(#{ resolve := R }) when is_function(R) ->
+    exit(wrong_resolver_arity);
+c_field_val_resolve(_) ->
+    undefined.
 
 c_field_val_args(#{ args := Args }) ->map_2(fun c_args/2, Args);
 c_field_val_args(_) -> #{}.


### PR DESCRIPTION


I was about to do directive introspection, but found this instead.

Seemed like a resolver with arity 3 was only ever used when a field's resolve is set.
This seems to mostly be a feature useful in the instrospection where you'd like to
overwrite a field resolver instead of using the resolve module on the object.
The blog example also inlines field resolvers, which makes sense for small applications.

However, it seemed like a convenience thing that should be handled in canonicalization
so I patched that so that a field resolver always has arity 4 in the execution.

- - -

I'd also like to unify the way the resolver is specified on objects and fields.
It's a bit weird that an object takes a `resolve_module` which must be a module,
and a field takes a `resolve` which must be a function.

Naming both `resolve` and accepting both an atom (which would call a module's execute)
or a function of arity 4 (or 3) seems to be more consistent, and makes it more obvious
that it's a list of possible resolvers, taking the field resolver if available, otherwise
using the object resolver.
That's a different patch though.