### PR TITLE
Adding directives to argument definitions

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -438,9 +438,7 @@ format_directives([#directive { id = N, args = Args }|Ds]) ->
     [#directive{ id = name(N),
                  args = maps:from_list(
                           [{name(ID), Value} || {ID, Value} <- Args])}
-     | format_directives(Ds)];
-format_directives([#directive_type { id = N, args = Args }|Ds]) ->
-    [#directive{ id = name(N), args = Args }| format_directives(Ds)].
+     | format_directives(Ds)].
 
 resolve_field_value(Ctx, #object_type { id = OID,
                                         directives = ODirectives} = ObjectType,

--- a/src/graphql_schema.hrl
+++ b/src/graphql_schema.hrl
@@ -30,7 +30,7 @@
 -record(enum_value,
         { val :: binary(),
           description :: binary(),
-          directives = [] :: [directive_type()],
+          directives = [] :: [graphql:directive()],
           deprecation = undefined :: undefined | binary()
         }).
 -type enum_value() :: #enum_value{}.
@@ -39,7 +39,7 @@
         { id :: binary(),
           description :: binary(),
           resolve_module = graphql_enum_coerce :: mod(),
-          directives = [] :: [directive_type()],
+          directives = [] :: [graphql:directive()],
           values :: #{ integer() => enum_value() }
         }).
 -type enum_type() :: #enum_type{}.
@@ -48,7 +48,7 @@
         { id :: binary(),
           description :: binary(),
           resolve_type :: mod() | fun ((any()) -> {ok, atom()} | {error, term()}),
-          directives = [] :: [directive_type()],
+          directives = [] :: [graphql:directive()],
           fields :: #{ binary() => schema_field() }
         }).
 -type interface_type() :: #interface_type{}.
@@ -57,7 +57,7 @@
         { id :: binary(),
           description :: binary(),
           resolve_type :: mod() | fun ((any()) -> {ok, atom()} | {error, term()}),
-          directives = [] :: [directive_type()],
+          directives = [] :: [graphql:directive()],
           types :: [binary() | {name, non_neg_integer(), binary()}]
         }).
 -type union_type() :: #union_type{}.
@@ -65,7 +65,8 @@
 -record(schema_arg,
         { ty :: schema_type(),
           default = null :: any(),
-          description :: binary()
+          description :: binary(),
+          directives = [] :: [graphql:directive()]
         }).
 -type schema_arg() :: #schema_arg{}.
 
@@ -75,7 +76,7 @@
           resolve = undefined :: undefined | resolver(),
           %% FIXME: deprecations are directives so they can be cast as one
           deprecation = undefined :: undefined | binary(),
-          directives = [] :: [directive_type()],
+          directives = [] :: [graphql:directive()],
           args = #{} :: #{ binary() => schema_arg() }
         }).
 -type schema_field() :: #schema_field{}.
@@ -83,7 +84,7 @@
 -record(scalar_type,
         { id :: binary(),
           description :: binary(),
-          directives = [] :: [directive_type()],
+          directives = [] :: [graphql:directive()],
           resolve_module = graphql_enum_coerce :: mod()
         }).
 -type scalar_type() :: #scalar_type{}.
@@ -91,7 +92,7 @@
 -record(input_object_type,
         { id :: binary(),
           description :: binary(),
-          directives = [] :: [directive_type() | graphql:directive()],
+          directives = [] :: [graphql:directive()],
           fields = #{} :: #{ binary() => schema_arg() }
         }).
 -type input_object_type() :: #input_object_type{}.
@@ -99,7 +100,7 @@
 -record(object_type,
         { id :: binary(),
           description :: binary(),
-          directives = [] :: [directive_type() | graphql:directive()],
+          directives = [] :: [graphql:directive()],
           resolve_module :: mod(),
           fields = #{} :: #{ binary() => schema_field() },
           interfaces = [] :: [binary()]
@@ -111,7 +112,7 @@
           query = undefined :: undefined | binary(),
           mutation = undefined :: undefined | binary(),
           subscription = undefined :: undefined | binary(),
-          directives = [] :: [directive_type()],
+          directives = [] :: [graphql:directive()],
           interfaces = [] :: [binary()]
         }).
 -type root_schema() :: #root_schema{}.

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -36,7 +36,9 @@ type Stats {
   shellScripting : Int
 }
 
-directive @private(scope: String) on FIELD_DEFINITION
+directive @private(scope: String) on
+  | FIELD_DEFINITION
+  | ARGUMENT_DEFINITION
 
 type Monster implements Node {
   id : ID!
@@ -45,7 +47,7 @@ type Monster implements Node {
   hitpoints : Int!
   inventory : [Thing]
   hp : Int!
-  mood(fail: Bool) : Mood @private
+  mood(fail: Bool @private) : Mood @private
   plushFactor : Float!
   spikyness : Float
   stats(

--- a/test/graphql_SUITE_data/test_schema.spec
+++ b/test/graphql_SUITE_data/test_schema.spec
@@ -67,7 +67,7 @@ type Monster implements Node {
   hp: Int!
   mood: Mood @fieldDefDirective(myarg: "Hello World")
   plushFactor: Float!
-  stats(minAttack: Int! = 0): [Stats]
+  stats(minAttack: Int! = 0 @myArgDirective): [Stats]
   properties: [Property]
 }
 
@@ -76,3 +76,6 @@ directive @execDefDirective on
   | FRAGMENT_SPREAD
 
 directive @fieldDefDirective(myarg: String) on FIELD_DEFINITION
+
+directive @myArgDirective on ARGUMENT_DEFINITION
+


### PR DESCRIPTION
We didn't actually store argument definition directives anywhere.

So I added a `directives` field to the `#schema_arg{}` record and store the directives there.

I also cleaned up some type info in graphql_schema.hrl. Most records had
```erl
directives :: [directive_type()]
```
which isn't correct, it should just be a list of `graphql:directive()`

After that, dialyzer found that `format_directives/1` never actually get's `directive_type()`
which makes sense, so I removed some unused code.

I also patched up the tests to make sure argument definition directives parse and validate.