### PR TITLE
Make include paths relative to fix compilation under hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ missing some parts. The implementation plan is on a demand driven
 basis for Shopgun currently, in that we tend to implement things when
 there is a need for them.
 
+# Installation
+
+This package is also available in Hex as [graphql_erl](https://hex.pm/packages/graphql_erl).
+
+## Elixir
+
+Add `graphql_erl` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:graphql_erl, "~> 0.16.0"}
+  ]
+end
+```
+
+To use it, call `:graphql_erl.parse(query)` etc.
+
 # Documentation
 
 This is a big library. In order to ease development, we have provided

--- a/src/graphql.erl
+++ b/src/graphql.erl
@@ -1,6 +1,6 @@
 -module(graphql).
 
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 -include("graphql_internal.hrl").
 -include("graphql_schema.hrl").
 

--- a/src/graphql_ast.erl
+++ b/src/graphql_ast.erl
@@ -1,6 +1,6 @@
 -module(graphql_ast).
 
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 -include("graphql_internal.hrl").
 -include("graphql_schema.hrl").
 

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -50,7 +50,7 @@
 %%% @end
 -module(graphql_check).
 
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 -include("graphql_internal.hrl").
 -include("graphql_schema.hrl").
 

--- a/src/graphql_err.erl
+++ b/src/graphql_err.erl
@@ -1,6 +1,6 @@
 -module(graphql_err).
 
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 -include("graphql_internal.hrl").
 -include("graphql_schema.hrl").
 

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -1,6 +1,6 @@
 -module(graphql_execute).
 
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 -include("graphql_internal.hrl").
 -include("graphql_schema.hrl").
 

--- a/src/graphql_introspection.erl
+++ b/src/graphql_introspection.erl
@@ -1,7 +1,7 @@
 -module(graphql_introspection).
 
 -include("graphql_schema.hrl").
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 
 -export([inject/0, augment_root/1]).
 

--- a/test/blog.erl
+++ b/test/blog.erl
@@ -1,5 +1,5 @@
 -module(blog).
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 
 -export([inject/0, execute/4]).
 

--- a/test/dungeon.erl
+++ b/test/dungeon.erl
@@ -1,6 +1,6 @@
 -module(dungeon).
 -include_lib("common_test/include/ct.hrl").
--include_lib("graphql/include/graphql.hrl").
+-include_lib("../include/graphql.hrl").
 -include_lib("stdlib/include/qlc.hrl").
 
 -include("dungeon.hrl").


### PR DESCRIPTION
This addresses #209.

All occurrences of `graphql/include/` in .erl files were replaced by `../include/`.