### PR TITLE
Fixup string bool handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ the compatibility issues you are likely to encounter.
 
 ## [Unreleased]
 
+### Compatibility
+
+* The error code `param_mismatch` was removed in lieu of
+  `type_mismatch` due to a rewrite in the type checker of error
+  handling.
+* The error code `non_null` will now report `type_mismatch` instead.
+* The error code `enum_not_found` will now be reported as
+  `unknown_enum`
+* If a string literal is given in place of an enum, the error code
+  will now be `enum_string_literal` rather than `enum_not_found`.
+
 ### Added
 
 * Add proper support for OTP release 21 (by getong, 18年梦醒). Detect the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ the compatibility issues you are likely to encounter.
   OTP 21 version, and if present, use the new stack-trace form. This
   ensures backwards compatibility as well as proper stack trace
   handling in new OTP releases.
+* New command `graphql:map/2`. Given a `Result` of the form `{ok, Val} |
+  {defer, Token}` the call to `graphql:map(F, Result)` will apply `F`
+  to the result. Either now, or in the case of a defer, when the defer
+  completes. This yields an alternative way to handle events which
+  cannot be completed right away. Long running work is usually better
+  handled in a spawned process, but simpler changes can be handled
+  within the context of the GraphQL process.
 * New command `graphql:sync/3`. Calling `graphql:sync(Ctx, Pid, Msg)`
   will place a message into the GraphQL mailbox. When this message
   occurs, we will send `Pid` a message `Msg`. This is useful for e.g.,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ the compatibility issues you are likely to encounter.
 
 ### Fixed
 
+* Default variable value expansion has been fixed. If you have a
+  situation where a field-arg has a default value, you have supplied a
+  parameter for that value, say `foo(x: $k)` and you then omit `$k` in
+  your query, the underlying default (in this case the default for
+  `x`) is now picked up properly.
 * Re-instate the operation type in the callers context
 * Remove the occurrence of fragment names in `path` components of
   errors. These are not allowed per the Jun2018 specification and

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ specification, except for a few areas:
 In addition, we are working towards June 2018 compliance. We already
 implemented many of the changes in the system. But we are still
 missing some parts. The implementation plan is on a demand driven
-basis for Shopgun currently, in that we tend to implement things are
+basis for Shopgun currently, in that we tend to implement things when
 there is a need for them.
 
 # Documentation

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -315,6 +315,8 @@ check_value(Ctx, null, {non_null, _} = Sigma) ->
 check_value(Ctx, Val, {non_null, Sigma}) ->
     check_value(Ctx, Val, Sigma);
 check_value(_Ctx, undefined, _Sigma) ->
+    %% Values not given are currently defaulted to the value null
+    %% @todo: Lift this curse
     {ok, null};
 check_value(_Ctx, null, _Sigma) ->
     %% Null values are accepted in every other context

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -303,7 +303,7 @@ check_value(Ctx, {var, ID}, Sigma) ->
     CtxP = add_path(Ctx, {var, ID}),
     {ok, #vardef { ty = Tau}} = infer(Ctx, {var, ID}),
     ok = sub_input(CtxP, Tau, Sigma),
-    {ok, {var, ID, Tau}};
+    {ok, #var { id = ID, ty = Tau }};
 check_value(Ctx, undefined, {non_null, _} = Sigma) ->
     err(Ctx, {type_mismatch,
               #{ document => undefined,
@@ -407,11 +407,9 @@ check_input_obj_(Ctx, Obj, [{Name, #schema_arg { ty = Ty,
             not_found ->
                 case check_not_found(CtxP, Ty, Default) of
                     undefined ->
-                        coerce_default_param(CtxP, Default, Ty);
+                        coerce_default_param(CtxP, null, Ty);
                     default ->
-                        coerce_default_param(CtxP, Default, Ty);
-                    {ok, Res} ->
-                        {ok, Res}
+                        coerce_default_param(CtxP, Default, Ty)
                 end;
             V ->
                 {ok, Tau} = infer_input_type(CtxP, Ty),
@@ -588,8 +586,6 @@ check_params_(#ctx { vars = VE } = Ctx, OrigParams) ->
                                 Parameters;
                             default ->
                                 {ok, Res} = coerce_default_param(CtxP, Default, Tau),
-                                Parameters#{ Key => Res };
-                            {ok, Res} ->
                                 Parameters#{ Key => Res }
                         end;
                     Value ->

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -376,7 +376,6 @@ check_input_obj_(Ctx, Obj, [], Acc) ->
         0 -> Acc;
         K when K > 0 -> err(Ctx, {excess_fields_in_object, Obj})
     end;
-%% @todo: Clearly this has to change because Ty isn't known at this
 check_input_obj_(Ctx, Obj, [{Name, #schema_arg { ty = Ty,
                                                  default = Default }} | Next],
                  Acc) ->

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -413,7 +413,13 @@ check_input_obj_(Ctx, Obj, [{Name, #schema_arg { ty = Ty,
                 end;
             V ->
                 {ok, Tau} = infer_input_type(CtxP, Ty),
-                check_value(CtxP, V, Tau)
+                case check_value(CtxP, V, Tau) of
+                    {ok, #var{} = Var} ->
+                        {ok, Coerced} = coerce_default_param(CtxP, Default, Ty),
+                        {ok, Var#var { default = Coerced }};
+                    {ok, Res} ->
+                        {ok, Res}
+                end
         end,
     check_input_obj_(Ctx,
                      maps:remove(Name, Obj),

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -580,7 +580,7 @@ check_param_(Ctx, Val, Ty) when is_binary(Ty) ->
     check_param_(Ctx, Val, Tau);
 check_param_(Ctx, {var, ID}, Sigma) ->
     CtxP = add_path(Ctx, {var, ID}),
-    {ok, #vardef { ty = Tau}} = infer(Ctx, {var, ID}),
+    {ok, #vardef { ty = Tau }} = infer(Ctx, {var, ID}),
     ok = sub_input(CtxP, Tau, Sigma),
     {ok, {var, ID, Tau}};
 check_param_(Ctx, null, {non_null, _}) ->

--- a/src/graphql_check.erl
+++ b/src/graphql_check.erl
@@ -380,16 +380,15 @@ check_input_obj_(Ctx, Obj, [], Acc) ->
 check_input_obj_(Ctx, Obj, [{Name, #schema_arg { ty = Ty,
                                                  default = Default }} | Next],
                  Acc) ->
-    Result = case maps:get(Name, Obj, not_found) of
-                 not_found ->
-                     {ok, R} = check_not_found(add_path(Ctx, Name), Ty, Default),
-                     R;
-                 V ->
-                     CtxP = add_path(Ctx, Name),
-                     {ok, Tau} = infer_input_type(CtxP, Ty),
-                     {ok, R} = check_param(CtxP, V, Tau),
-                     R
-             end,
+    CtxP = add_path(Ctx, Name),
+    {ok, Result} =
+        case maps:get(Name, Obj, not_found) of
+            not_found ->
+                check_not_found(CtxP, Ty, Default);
+            V ->
+                {ok, Tau} = infer_input_type(CtxP, Ty),
+                check_param(CtxP, V, Tau)
+        end,
     check_input_obj_(Ctx,
                      maps:remove(Name, Obj),
                      Next,

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -974,10 +974,12 @@ var_coerce(Tau, {list, SType}, Value)                 -> [var_coerce(Tau, SType,
 value(Ctx, {Ty, Val})                     -> value(Ctx, Ty, Val);
 value(Ctx, #{ type := Ty, value := Val }) -> value(Ctx, Ty, Val).
 
-value(#ectx{ params = Params } = _Ctx, SType, {var, ID, DType}) ->
+value(#ectx{ params = Params } = Ctx, SType, {var, ID, DType}) ->
     %% Parameter expansion and type check is already completed
     %% at this stage
     case maps:get(name(ID), Params, not_found) of
+        not_found ->
+            exit(no_default_yet);
         Value ->
             var_coerce(DType, SType, Value)
     end;

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -956,16 +956,18 @@ resolve_args_(Ctx, [{ID, Val} | As], Acc) ->
 %%
 %% For a discussion about the Pet -> [Pet] coercion in the
 %% specification, see (Oct2016 Section 3.1.7)
-var_coerce(S, T, V) when is_binary(S)                 ->
-    X = graphql_schema:lookup(S),
-    var_coerce(X, T, V);
-var_coerce(S, T, V) when is_binary(T)                 ->
-    X = graphql_schema:lookup(T),
-    var_coerce(S, X, V);
-var_coerce(Tau, Tau, Value)                           -> Value;
+var_coerce(Tau, Sigma, V) when is_binary(Sigma)       ->
+    X = graphql_schema:lookup(Sigma),
+    var_coerce(Tau, X, V);
+var_coerce(Tau, Sigma, V) when is_binary(Tau)         ->
+    X = graphql_schema:lookup(Tau),
+    var_coerce(X, Sigma, V);
+var_coerce(Refl, Refl, Value)                         -> Value;
 var_coerce({non_null, Tau}, {non_null, Sigma}, Value) ->
     var_coerce(Tau, Sigma, Value);
 var_coerce({non_null, Tau}, Tau, Value)               -> Value;
+var_coerce({list, Tau}, {list, Sigma}, Values) ->
+    var_coerce(Tau, Sigma, Values);
 var_coerce(Tau, {list, SType}, Value)                 -> [var_coerce(Tau, SType, Value)].
 
 %% Produce a valid value for an argument.

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -980,7 +980,11 @@ value(#ectx{ params = Params }, SType, #var { id = ID, ty = DType,
     %% at this stage
     case maps:get(name(ID), Params, not_found) of
         not_found ->
-            var_coerce(DType, SType, Default);
+            case Default of
+                %% Coerce undefined values to "null"
+                undefined -> var_coerce(DType, SType, null);
+                _ -> var_coerce(DType, SType, Default)
+            end;
         Value ->
             var_coerce(DType, SType, Value)
     end;

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -974,12 +974,13 @@ var_coerce(Tau, {list, SType}, Value)                 -> [var_coerce(Tau, SType,
 value(Ctx, {Ty, Val})                     -> value(Ctx, Ty, Val);
 value(Ctx, #{ type := Ty, value := Val }) -> value(Ctx, Ty, Val).
 
-value(#ectx{ params = Params }, SType, #var { id = ID, ty = DType }) ->
+value(#ectx{ params = Params }, SType, #var { id = ID, ty = DType,
+                                              default = Default }) ->
     %% Parameter expansion and type check is already completed
     %% at this stage
     case maps:get(name(ID), Params, not_found) of
         not_found ->
-            exit(no_default_yet);
+            var_coerce(DType, SType, Default);
         Value ->
             var_coerce(DType, SType, Value)
     end;

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -974,7 +974,7 @@ var_coerce(Tau, {list, SType}, Value)                 -> [var_coerce(Tau, SType,
 value(Ctx, {Ty, Val})                     -> value(Ctx, Ty, Val);
 value(Ctx, #{ type := Ty, value := Val }) -> value(Ctx, Ty, Val).
 
-value(#ectx{ params = Params } = Ctx, SType, {var, ID, DType}) ->
+value(#ectx{ params = Params }, SType, #var { id = ID, ty = DType }) ->
     %% Parameter expansion and type check is already completed
     %% at this stage
     case maps:get(name(ID), Params, not_found) of

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -988,6 +988,8 @@ value(#ectx{ params = Params }, SType, #var { id = ID, ty = DType,
         Value ->
             var_coerce(DType, SType, Value)
     end;
+value(_Ctx, _Ty, undefined) ->
+    null;
 value(_Ctx, _Ty, null) ->
     null;
 value(Ctx, {non_null, Ty}, Val) ->

--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -977,8 +977,10 @@ value(Ctx, #{ type := Ty, value := Val }) -> value(Ctx, Ty, Val).
 value(#ectx{ params = Params } = _Ctx, SType, {var, ID, DType}) ->
     %% Parameter expansion and type check is already completed
     %% at this stage
-    Value = maps:get(name(ID), Params),
-    var_coerce(DType, SType, Value);
+    case maps:get(name(ID), Params, not_found) of
+        Value ->
+            var_coerce(DType, SType, Value)
+    end;
 value(_Ctx, _Ty, null) ->
     null;
 value(Ctx, {non_null, Ty}, Val) ->

--- a/src/graphql_internal.hrl
+++ b/src/graphql_internal.hrl
@@ -59,6 +59,11 @@
           default = undefined :: undefined | value()
         }).
 
+-record(var,
+       { id :: graphql:name(),
+         ty :: graphql_type(),
+         default = undefined :: undefined | value() }).
+
 -record(op,
         { ty :: undefined | operation_type(),
           id = 'ROOT' :: graphql:name() | 'ROOT',

--- a/src/graphql_internal.hrl
+++ b/src/graphql_internal.hrl
@@ -28,7 +28,9 @@
 
 -record(field, {
 	id :: graphql:name(),
-	args = [] :: [any()],
+	args = [] :: [#{ type := graphql_type(),
+                        value := value(),
+                        default := undefined | value() }],
 	directives = [] :: [any()],
 	selection_set = [] :: [any()],
 	alias = undefined :: undefined | graphql:name(),

--- a/src/graphql_internal.hrl
+++ b/src/graphql_internal.hrl
@@ -54,7 +54,7 @@
 -record(vardef,
         { id :: graphql:name(),
           ty :: graphql_type(),
-          default = null :: value()
+          default = undefined :: undefined | value()
         }).
 
 -record(op,
@@ -91,7 +91,7 @@
 -record(p_input_value,
         { id :: graphql:name(),
           description = undefined :: 'undefined' | binary(),
-          default = null :: any(),
+          default = undefined :: undefined | value(),
           directives = [] :: [graphql:directive()],          
           type :: graphql_type()
         }).

--- a/src/graphql_introspection.erl
+++ b/src/graphql_introspection.erl
@@ -182,7 +182,11 @@ render_input_value({K, #schema_arg { ty = Ty,
         <<"name">> => K,
         <<"description">> => Desc,
         <<"type">> => ?LAZY(render_type(Ty)),
-        <<"defaultValue">> => Default
+        <<"defaultValue">> =>
+              case Default of
+                  undefined -> null;
+                  _ -> Default
+              end
     }}.
 
 interface_implementors(ID) ->

--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -107,7 +107,7 @@ VariableDefinitionList -> VariableDefinition : ['$1'].
 VariableDefinitionList -> VariableDefinition VariableDefinitionList : ['$1'|'$2'].
 
 VariableDefinition -> Variable ':' Type :
-    #vardef { id = '$1', ty = '$3', default = null }.
+    #vardef { id = '$1', ty = '$3' }.
 VariableDefinition -> Variable ':' Type DefaultValue :
     #vardef { id = '$1', ty = '$3', default = '$4' }.
 

--- a/src/graphql_scalar_bool_coerce.erl
+++ b/src/graphql_scalar_bool_coerce.erl
@@ -3,7 +3,9 @@
 -export([input/2, output/2]).
 
 input(_, true) -> {ok, true};
+input(_, <<"true">>) -> {ok, true};
 input(_, false) -> {ok, false};
+input(_, <<"false">>) -> {ok, false};
 input(_, _) -> {error, not_bool}.
 
 output(<<"Bool">>, true)                 -> {ok, true};

--- a/src/graphql_schema_canonicalize.erl
+++ b/src/graphql_schema_canonicalize.erl
@@ -113,7 +113,7 @@ c_input_value_val(#{ type := _, description := _ } = M) ->
     c_arg_val(M). % these functions are currently identical
 
 default(#{ default := Def }) -> Def;
-default(#{ }) -> null.
+default(#{ }) -> undefined.
 
 c_field(K, V) ->
     {binarize(K), c_field_val(V)}.

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -444,7 +444,7 @@ populate(Config) ->
               #{<<"introduceMonster">> =>
                     #{<<"clientMutationId">> => <<"123">>,
                       <<"monster">> =>
-                          #{<<"color">> => <<"#ffffff">>,
+                          #{<<"color">> => <<"#FFFFFF">>,
                             <<"hitpoints">> => 1,
                             <<"id">> => <<"bW9uc3RlcjoxMDA5">>,
                             <<"mood">> => <<"DODGY">>,
@@ -825,6 +825,7 @@ fragment_over_union_interface(Config) ->
 find_monster(Config) ->
     Expected1 =
         lists:sort([#{<<"name">> => <<"goblin!">>},
+                    #{<<"name">> => <<"Teeny Tiny Mouse!">>},
                     #{<<"name">> => <<"Auxiliary Undead!">>},
                     #{<<"name">> => <<"goblin!">>},
                     #{<<"name">> => <<"goblin!">>},
@@ -886,6 +887,7 @@ find_monster_singleton(Config) ->
     Expected1 =
         lists:sort(
           [#{<<"name">> => <<"goblin!">>},
+           #{<<"name">> => <<"Teeny Tiny Mouse!">>},
            #{<<"name">> => <<"Auxiliary Undead!">>},
            #{<<"name">> => <<"goblin!">>},
            #{<<"name">> => <<"goblin!">>},

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -55,51 +55,50 @@ end_per_testcase(_Case, _Config) ->
 groups() ->
     Dungeon =
         {dungeon, [],
-         [ unions
-         , defer
-         , union_errors
-         , error_handling
-         , scalar_output_coercion
-         , populate
-         , default_query
-         , direct_input
-         , fixed_input
-         , nested_input_object
-         , inline_fragment
-         , fragment_over_union_interface
-         , integer_in_float_context
-         , scalar_as_expression_coerce
-         , non_null_field
-         , complex_modifiers
-         , simple_field_merge
-         , nested_field_merge
-         , multiple_monsters_and_rooms
-         , include_directive
-         , introspection
-         , introspection_with_variable
-         , get_operation
-         , coercion_int_float
-         , replace_enum_representation
-         , auxiliary_data
-         , find_monster
-         , find_monster_singleton
-         , invalid_scalar_int_input
-         , introspect_default_value
-         ]},
+         [ unions,
+           defer,
+           union_errors,
+           error_handling,
+           scalar_output_coercion,
+           populate,
+           default_query,
+           direct_input,
+           fixed_input,
+           nested_input_object,
+           inline_fragment,
+           fragment_over_union_interface,
+           integer_in_float_context,
+           scalar_as_expression_coerce,
+           non_null_field,
+           complex_modifiers,
+           simple_field_merge,
+           nested_field_merge,
+           multiple_monsters_and_rooms,
+           include_directive,
+           introspection,
+           introspection_with_variable,
+           get_operation,
+           coercion_int_float,
+           replace_enum_representation,
+           auxiliary_data,
+           find_monster,
+           find_monster_singleton,
+           invalid_scalar_int_input,
+           introspect_default_value,
+           default_parameter ]},
     Errors =
         {errors, [],
-         [ unknown_variable
-         , null_input
-         , missing_fragment
-         , quoted_input_error
-         , input_coerce_error_exception
-         , input_coerce_error
-         , invalid_enums
-         , invalid_enum_result
-         , invalid_type_resolution
-         , duplicate_validation
-         , invalid_list_resolver
-         ]},
+         [ unknown_variable,
+           null_input,
+           missing_fragment,
+           quoted_input_error,
+           input_coerce_error_exception,
+           input_coerce_error,
+           invalid_enums,
+           invalid_enum_result,
+           invalid_type_resolution,
+           duplicate_validation,
+           invalid_list_resolver ]},
     %% Groups
     [ Dungeon
     , Errors
@@ -1092,4 +1091,18 @@ input_coerce_error_exception(Config) ->
                             <<"input">>,
                             <<"color">>]}]} =
         run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input }),
+    ok.
+
+default_parameter(Config) ->
+    ct:log("Run, and provide a colorType explicitly"),
+    #{ data :=
+           #{ <<"monster">> :=
+                  #{ <<"color">> := <<"#727272">>}}} =
+        run(Config, <<"GetMonster">>, #{ <<"id">> => <<"bW9uc3Rlcjox">>,
+                                         <<"colorType">> => <<"gray">> }),
+    ct:log("Run, and pick up the color type via the argument default"),
+    #{ data :=
+           #{ <<"monster">> :=
+                  #{ <<"color">> := <<"#41924B">>}}} =
+        run(Config, <<"GetMonster">>, #{ <<"id">> => <<"bW9uc3Rlcjox">> }),
     ok.

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -671,7 +671,8 @@ scalar_as_expression_coerce(Config) ->
                                                     <<"attack">> := 7,
                                                     <<"shellScripting">> := 5,
                                                     <<"yell">> := <<"...">> }]}}}} =
-             run(Config, <<"IntroduceMonsterFatExpr">>, #{}),
+             run(Config, <<"IntroduceMonsterFatExpr">>, #{ <<"properties">> => [<<"MURLOC">>,
+                                                                                <<"MECH">>]}),
     true = (PF - 0.01) < 0.00001,
     ok.
 

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -418,6 +418,47 @@ populate(Config) ->
 
     ExpectedNestedInput = run(Config, <<"IntroduceMonsterNestedVar">>, NestedInput),
 
+
+    ExpectedDefaultNestedInput =
+        #{data =>
+              #{<<"introduceMonster">> =>
+                    #{<<"clientMutationId">> => <<"123">>,
+                      <<"monster">> =>
+                          #{<<"color">> => <<"#444444">>,
+                            <<"hitpoints">> => 9001,
+                            <<"id">> => <<"bW9uc3RlcjoxMDA4">>,
+                            <<"mood">> => <<"AGGRESSIVE">>,
+                            <<"name">> => <<"Tiny Evil Cat">>,
+                            <<"plushFactor">> => 57.0,
+                            <<"properties">> => [<<"BEAST">>],
+                            <<"stats">> =>
+                                [#{<<"attack">> => 1337,
+                                   <<"shellScripting">> => 10,
+                                   <<"yell">> =>
+                                       <<"Purrrrrrrrrrrrrr!">>}]}}}},
+
+    ExpectedDefaultNestedInput = run(Config, <<"IntroduceMonsterDefaultNestedVar">>, #{}),
+
+    ExpectedOptionalNestedInput =
+        #{data =>
+              #{<<"introduceMonster">> =>
+                    #{<<"clientMutationId">> => <<"123">>,
+                      <<"monster">> =>
+                          #{<<"color">> => <<"#ffffff">>,
+                            <<"hitpoints">> => 1,
+                            <<"id">> => <<"bW9uc3RlcjoxMDA5">>,
+                            <<"mood">> => <<"DODGY">>,
+                            <<"name">> => <<"Teeny Tiny Mouse">>,
+                            <<"plushFactor">> => 10.0,
+                            <<"properties">> => [<<"BEAST">>],
+                            <<"stats">> =>
+                                [#{<<"attack">> => 1,
+                                   <<"shellScripting">> => 1,
+                                   <<"yell">> =>
+                                       <<"Meek!">>}]}}}},
+
+    ExpectedOptionalNestedInput = run(Config, <<"IntroduceMonsterOptionalNestedVar">>, #{}),
+
     ct:log("Check duplicate enum values (BEAST mood/property)"),
 
     DupEnumInput = #{

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -929,9 +929,9 @@ null_input(Config) ->
                  [<<"TestNullInput">>,<<"room">>,
                   <<"id">>]}]} = run(Config, <<"test_null_input_2.graphql">>, <<"TestNullInput">>, #{}),
     %% The following bugs must fail because the value is null which is not allowed
-    #{ errors := [#{ extensions := #{ code := non_null }}]} =
+    #{ errors := [#{ extensions := #{ code := type_mismatch }}]} =
         run(Config, <<"test_null_input_3.graphql">>, <<"TestNullInput">>, #{}),
-    #{ errors := [#{ extensions := #{ code := non_null }}]} =
+    #{ errors := [#{ extensions := #{ code := type_mismatch }}]} =
         run(Config, <<"test_null_input_4.graphql">>, <<"TestNullInput">>,
             #{ <<"input">> =>
                    #{ <<"name">> => <<"Orc">>,
@@ -972,33 +972,27 @@ invalid_enums(Config) ->
       <<"mood">> => <<"AGGRESSIF">>
      },
     #{errors :=
-          [#{ extensions := #{ code := enum_not_found },
-              message := <<"The value <<\"AGGRESSIF\">> is not a valid enum value for type Mood">>,
+          [#{ extensions := #{ code := unknown_enum },
               path := [<<"IntroduceMonster">>,<<"input">>,<<"mood">>]}]} =
         run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input }),
     #{errors :=
-          [ #{ extensions := #{ code := enum_not_found },
-               message := <<"The value <<>> is not a valid enum value for type Mood">>,
+          [ #{ extensions := #{ code := unknown_enum },
                path := [<<"IntroduceMonster">>,<<"input">>,<<"mood">>]}]} =
         run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input#{ <<"mood">> => <<"">> }}),
     #{errors :=
-          [#{extensions := #{ code := enum_not_found },
-             message := <<"The value <<>> is not a valid enum value for type Mood">>,
+          [#{extensions := #{ code := unknown_enum },
              path := [<<"IntroduceMonster">>,<<"input">>,<<"mood">>]}]} =
           run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input#{ <<"mood">> => <<>> }}),
     #{errors :=
-      [#{extensions := #{ code := param_mismatch },
-         message := <<"The enum value matches types [Property] but was used in a context where an enum value of type Mood was expected">>,
+      [#{extensions := #{ code := type_mismatch },
          path := [<<"IntroduceMonster">>,<<"input">>,<<"mood">>]}]} =
         run(Config, <<"IntroduceMonster">>, #{ <<"input">> => Input#{ <<"mood">> => <<"DRAGON">> }}),
     #{ errors :=
-           [#{ extensions := #{  code := enum_not_found },
-               message := <<"The value <<\"AGGRESSIF\">> is not a valid enum value for type Mood">>,
+           [#{ extensions := #{  code := unknown_enum },
                path := [<<"IMonster">>,<<"introduceMonster">>, <<"input">>, <<"mood">>]}]} =
         run(Config, "invalid_enum_1.graphql", <<"IMonster">>, #{}),
     #{ errors :=
-           [#{ extensions := #{ code := enum_not_found },
-               message := <<"The value <<>> is not a valid enum value for type Mood">>,
+           [#{ extensions := #{ code := enum_string_literal },
                path := [<<"IMonster">>,<<"introduceMonster">>, <<"input">>, <<"mood">>]}]} =
         run(Config, "invalid_enum_2.graphql", <<"IMonster">>, #{}),
     ok.

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -418,7 +418,6 @@ populate(Config) ->
 
     ExpectedNestedInput = run(Config, <<"IntroduceMonsterNestedVar">>, NestedInput),
 
-
     ExpectedDefaultNestedInput =
         #{data =>
               #{<<"introduceMonster">> =>
@@ -458,6 +457,29 @@ populate(Config) ->
                                        <<"Meek!">>}]}}}},
 
     ExpectedOptionalNestedInput = run(Config, <<"IntroduceMonsterOptionalNestedVar">>, #{}),
+
+
+    ct:log("Check for proper null-handling"),
+
+    ExpectedNullHandling =
+        #{data =>
+              #{<<"introduceMonster">> =>
+                    #{<<"clientMutationId">> => <<"123">>,
+                      <<"monster">> =>
+                          #{<<"color">> => <<"#000">>,
+                            <<"hitpoints">> => 9002,
+                            <<"id">> => <<"bW9uc3RlcjoxMDEw">>,
+                            <<"mood">> => <<"DODGY">>,
+                            <<"name">> => <<"Tiny Black Hole">>,
+                            <<"plushFactor">> => 0.01,
+                            <<"properties">> => [<<"BEAST">>],
+                            <<"stats">> =>
+                                [#{<<"attack">> => 1,
+                                   <<"shellScripting">> => 1,
+                                   <<"yell">> =>
+                                       <<"...">>}]}}}},
+
+    ExpectedNullHandling = run(Config, <<"IntroduceMonsterNullHandling">>, #{}),
 
     ct:log("Check duplicate enum values (BEAST mood/property)"),
 
@@ -826,6 +848,7 @@ find_monster(Config) ->
     Expected1 =
         lists:sort([#{<<"name">> => <<"goblin!">>},
                     #{<<"name">> => <<"Teeny Tiny Mouse!">>},
+                    #{<<"name">> => <<"Tiny Black Hole!">>},
                     #{<<"name">> => <<"Auxiliary Undead!">>},
                     #{<<"name">> => <<"goblin!">>},
                     #{<<"name">> => <<"goblin!">>},
@@ -888,6 +911,7 @@ find_monster_singleton(Config) ->
         lists:sort(
           [#{<<"name">> => <<"goblin!">>},
            #{<<"name">> => <<"Teeny Tiny Mouse!">>},
+           #{<<"name">> => <<"Tiny Black Hole!">>},
            #{<<"name">> => <<"Auxiliary Undead!">>},
            #{<<"name">> => <<"goblin!">>},
            #{<<"name">> => <<"goblin!">>},

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -125,11 +125,11 @@ run(Config, File, Q, Params) ->
 
 default_query(Config) ->
     ID = ?config(known_goblin_id_1, Config),
-    #{ data := #{ <<"goblin">> := #{ <<"id">> := ID, <<"name">> := <<"goblin">>, <<"hitpoints">> := 10 }}} =
+    #{ data := #{ <<"goblin">> := #{ <<"id">> := ID, <<"name">> := <<"goblin!">>, <<"hitpoints">> := 10 }}} =
         run(Config, <<"GoblinQuery">>, #{}),
-    #{ data := #{ <<"goblin">> := #{ <<"id">> := ID, <<"name">> := <<"goblin">>, <<"stats">> := [#{ <<"attack">> := 3 }] }}} =
+    #{ data := #{ <<"goblin">> := #{ <<"id">> := ID, <<"name">> := <<"goblin!">>, <<"stats">> := [#{ <<"attack">> := 3 }] }}} =
         run(Config, <<"MinGoblin">>, #{<<"minAttack">> => 0 }),
-    #{ data := #{ <<"goblin">> := #{ <<"id">> := ID, <<"name">> := <<"goblin">>, <<"stats">> := [] }}} =
+    #{ data := #{ <<"goblin">> := #{ <<"id">> := ID, <<"name">> := <<"goblin!">>, <<"stats">> := [] }}} =
         run(Config, <<"MinGoblin">>, #{<<"minAttack">> => 30 }),
     ok.
 
@@ -188,7 +188,7 @@ coercion_int_float(Config) ->
 
 get_operation(Config) ->
     GoblinId = ?config(known_goblin_id_1, Config),
-    Expected = #{ data => #{<<"monster">> => #{ <<"name">> => <<"goblin">> }}},
+    Expected = #{ data => #{<<"monster">> => #{ <<"name">> => <<"goblin!">> }}},
     Q1 = "{ monster(id: \"" ++ binary_to_list(GoblinId) ++ "\") { name }}",
     Expected = th:x(Config, Q1),
     Q2 = "query Q { monster(id: \"" ++ binary_to_list(GoblinId) ++ "\") { name }}",
@@ -211,7 +211,7 @@ include_directive(Config) ->
     #{ data := #{
          <<"goblin">> := #{
              <<"id">> := GoblinId,
-             <<"name">> := <<"goblin">>,
+             <<"name">> := <<"goblin!">>,
              <<"hitpoints">> := 10 }}} =
         run(Config, <<"GoblinQueryDirectives">>, #{ <<"fat">> => true }),
 
@@ -226,7 +226,7 @@ include_directive(Config) ->
     #{ data := #{
          <<"goblin">> := #{
              <<"id">> := GoblinId,
-             <<"name">> := <<"goblin">>,
+             <<"name">> := <<"goblin!">>,
              <<"hitpoints">> := 10 }}} =
         run(Config, <<"GoblinQueryDirectivesInline">>, #{ <<"fat">> => true }),
     ok.
@@ -239,21 +239,21 @@ unions(Config) ->
     Expected1 = #{ data => #{
                      <<"goblin">> => #{
                      <<"id">> => OpaqueId,
-                     <<"name">> => <<"goblin">>,
+                     <<"name">> => <<"goblin!">>,
                      <<"hitpoints">> => 10 }}},
     Expected1 = run(Config, <<"GoblinQuery">>, #{<<"id">> => OpaqueId}),
     ct:log("Same query, but on items"),
     Expected2 = #{ data => #{
                      <<"goblin">> => #{
                          <<"id">> => OpaqueId,
-                         <<"name">> => <<"goblin">>,
+                         <<"name">> => <<"goblin!">>,
                          <<"hitpoints">> => 10 }}},
     Expected2 = run(Config, <<"GoblinThingQuery">>, #{ <<"id">> => OpaqueId }),
     ct:log("Union expansions"),
     Expected3 = #{ data => #{ <<"things">> => [#{}]}},
     Expected3 = run(Config, <<"ThingQ1">>, #{ }),
 
-    Expected4 = #{ data => #{ <<"things">> => [#{ <<"__typename">> => <<"Monster">>, <<"name">> => <<"goblin">> }]}},
+    Expected4 = #{ data => #{ <<"things">> => [#{ <<"__typename">> => <<"Monster">>, <<"name">> => <<"goblin!">> }]}},
     Expected4 = run(Config, <<"ThingQ2">>, #{ }),
 
     Expected5 = #{ data => #{ <<"things">> => [#{ <<"__typename">> => <<"Monster">> }]}},
@@ -283,7 +283,7 @@ scalar_output_coercion(Config) ->
     #{ data := #{
         <<"goblin">> := #{
             <<"id">> := OpaqueId,
-            <<"name">> := <<"goblin">>,
+            <<"name">> := <<"goblin!">>,
             <<"color">> := <<"#41924B">>,
             <<"hitpoints">> := 10 }}} =
         run(Config, <<"ScalarOutputCoercion">>, #{ <<"id">> => OpaqueId }),
@@ -782,14 +782,14 @@ fragment_over_union_interface(Config) ->
 
 find_monster(Config) ->
     Expected1 =
-        lists:sort([#{<<"name">> => <<"goblin">>},
-                    #{<<"name">> => <<"Auxiliary Undead">>},
-                    #{<<"name">> => <<"goblin">>},
-                    #{<<"name">> => <<"goblin">>},
-                    #{<<"name">> => <<"hobgoblin">>},
-                    #{<<"name">> => <<"Yellow Slime">>},
-                    #{<<"name">> => <<"goblin">>},
-                    #{<<"name">> => <<"goblin">>}]),
+        lists:sort([#{<<"name">> => <<"goblin!">>},
+                    #{<<"name">> => <<"Auxiliary Undead!">>},
+                    #{<<"name">> => <<"goblin!">>},
+                    #{<<"name">> => <<"goblin!">>},
+                    #{<<"name">> => <<"hobgoblin!">>},
+                    #{<<"name">> => <<"Yellow Slime!">>},
+                    #{<<"name">> => <<"goblin!">>},
+                    #{<<"name">> => <<"goblin!">>}]),
     #{ data := #{<<"findMonsters">> := Out1 }} = run(Config, <<"FindQuery">>, #{}),
     Expected1 = lists:sort(Out1),
     #{ data := #{<<"findMonsters">> := Out2 }} = run(Config, <<"FindQueryParam">>, #{ <<"m">> => [<<"DODGY">>]}),
@@ -843,14 +843,14 @@ defer(Config) ->
 find_monster_singleton(Config) ->
     Expected1 =
         lists:sort(
-          [#{<<"name">> => <<"goblin">>},
-           #{<<"name">> => <<"Auxiliary Undead">>},
-           #{<<"name">> => <<"goblin">>},
-           #{<<"name">> => <<"goblin">>},
-           #{<<"name">> => <<"hobgoblin">>},
-           #{<<"name">> => <<"Yellow Slime">>},
-           #{<<"name">> => <<"goblin">>},
-           #{<<"name">> => <<"goblin">>}]),
+          [#{<<"name">> => <<"goblin!">>},
+           #{<<"name">> => <<"Auxiliary Undead!">>},
+           #{<<"name">> => <<"goblin!">>},
+           #{<<"name">> => <<"goblin!">>},
+           #{<<"name">> => <<"hobgoblin!">>},
+           #{<<"name">> => <<"Yellow Slime!">>},
+           #{<<"name">> => <<"goblin!">>},
+           #{<<"name">> => <<"goblin!">>}]),
     #{ data := #{ <<"findMonsters">> := Out1 }} = run(Config, <<"FindQuerySingleton">>, #{}),
     Expected1 = lists:sort(Out1),
     #{ data := #{ <<"findMonsters">> := Out2 }} = run(Config, <<"FindQueryParamSingleton">>, #{ <<"m">> => <<"DODGY">>}),
@@ -886,7 +886,7 @@ auxiliary_data(Config) ->
     Expected = #{
       aux => [{my_auxiliary_data, true}],
       data => #{ <<"monster">> => #{ <<"id">> => OpaqueId
-                                   , <<"name">> => <<"Auxiliary Undead">>}
+                                   , <<"name">> => <<"Auxiliary Undead!">>}
                }
      },
     Expected = run(Config, <<"TestAuxiliaryData">>, #{<<"id">> => OpaqueId}).

--- a/test/dungeon_SUITE_data/dungeon_schema.graphql
+++ b/test/dungeon_SUITE_data/dungeon_schema.graphql
@@ -103,7 +103,7 @@ input IntroduceMonsterInput {
   name : String!
   color : Color!
   hitpoints : Int = 15
-  plushFactor : Float = 0.01
+  plushFactor : Float
   mood : Mood = DODGY
   properties : [Property] = []
   stats : [StatsInput]

--- a/test/dungeon_SUITE_data/query.graphql
+++ b/test/dungeon_SUITE_data/query.graphql
@@ -352,14 +352,14 @@ mutation IntroduceMonsterFatFixedInput {
     }
 }
 
-mutation IntroduceMonsterFatExpr {
+mutation IntroduceMonsterFatExpr($properties : [Property]) {
   introduceMonster(input:
     { clientMutationId: "123",
       name: "Green Slime",
       color: "#1be215",
       hitpoints: 9001,
       mood: TRANQUIL,
-      properties: [MURLOC, MECH],
+      properties: $properties,
       stats: [{
         attack: 7,
         shellScripting: 5,

--- a/test/dungeon_SUITE_data/query.graphql
+++ b/test/dungeon_SUITE_data/query.graphql
@@ -130,6 +130,14 @@ query MultipleMonsters($ids : [Id!]) {
     }
 }
 
+query GetMonster($id : ID!, $colorType : ColorType) {
+    monster(id: $id) {
+        id
+        name
+        color(colorType : $colorType)
+    }
+}
+
 query MultipleMonstersExpr {
     monsters(ids: ["bW9uc3Rlcjox", "bW9uc3Rlcjoy"]) {
         id

--- a/test/dungeon_SUITE_data/query.graphql
+++ b/test/dungeon_SUITE_data/query.graphql
@@ -379,7 +379,7 @@ mutation IntroduceMonsterFatExpr($properties : [Property]) {
     }
 }
 
-mutation IntroduceMonsterNestedVar($mood : Mood!) {
+mutation IntroduceMonsterNestedVar($mood : Mood = AGGRESSIVE) {
   introduceMonster(input:
     { clientMutationId: "123",
       name: "Giant Spider",
@@ -391,6 +391,62 @@ mutation IntroduceMonsterNestedVar($mood : Mood!) {
         attack: 12,
         shellScripting: 0,
         yell: "I LOVE WEAVING!"
+      }]
+    }) {
+      clientMutationId,
+      monster {
+        ...FatMonsterFragment
+        plushFactor
+        stats {
+          attack
+          shellScripting
+          yell
+        }
+      }
+    }
+}
+
+mutation IntroduceMonsterDefaultNestedVar($mood : Mood = AGGRESSIVE) {
+  introduceMonster(input:
+    { clientMutationId: "123",
+      name: "Tiny Evil Cat",
+      color: "#444444", # Cats are very grey!
+      hitpoints: 9001,
+      mood: $mood,
+      properties: [BEAST],
+      plushFactor: 57.0,
+      stats: [{
+        attack: 1337,
+        shellScripting: 10,
+        yell: "Purrrrrrrrrrrrrr!"
+      }]
+    }) {
+      clientMutationId,
+      monster {
+        ...FatMonsterFragment
+        plushFactor
+        stats {
+          attack
+          shellScripting
+          yell
+        }
+      }
+    }
+}
+
+mutation IntroduceMonsterOptionalNestedVar($mood : Mood) {
+  introduceMonster(input:
+    { clientMutationId: "123",
+      name: "Teeny Tiny Mouse",
+      color: "#ffffff", # Makes your eyes bleed
+      hitpoints: 1,
+      mood: $mood,
+      properties: [BEAST],
+      plushFactor: 10.0,
+      stats: [{
+        attack: 1,
+        shellScripting: 1,
+        yell: "Meek!"
       }]
     }) {
       clientMutationId,

--- a/test/dungeon_SUITE_data/query.graphql
+++ b/test/dungeon_SUITE_data/query.graphql
@@ -462,6 +462,33 @@ mutation IntroduceMonsterOptionalNestedVar($mood : Mood) {
     }
 }
 
+mutation IntroduceMonsterNullHandling($pf : Float) {
+  introduceMonster(input:
+    { clientMutationId: "123",
+      name: "Tiny Black Hole",
+      color: "#000000", # Makes your eyes bleed
+      hitpoints: 9002,
+      properties: [BEAST],
+      plushFactor: $pf,
+      stats: [{
+        attack: 1,
+        shellScripting: 1,
+        yell: "..."
+      }]
+    }) {
+      clientMutationId,
+      monster {
+        ...FatMonsterFragment
+        plushFactor
+        stats {
+          attack
+          shellScripting
+          yell
+        }
+      }
+    }
+}
+
 mutation IntroduceRoom($input: IntroduceRoomInput!) {
   introduceRoom(input: $input) {
     clientMutationId

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -20,7 +20,7 @@ execute(Ctx, #monster { id = ID,
     case Field of
         <<"id">> -> graphql:throw(dungeon:wrap({monster, ID}));
         <<"name">> ->
-            ct:pal("Name Context Directives: ~p", [maps:get(field_directives, Ctx)]),
+            ct:log("Name Context Directives: ~p", [maps:get(field_directives, Ctx)]),
             NameToken = graphql:token(Ctx),
             spawn_link(fun() ->
                                graphql:reply_cast(NameToken, {ok, Name})

--- a/test/dungeon_monster.erl
+++ b/test/dungeon_monster.erl
@@ -25,7 +25,9 @@ execute(Ctx, #monster { id = ID,
             spawn_link(fun() ->
                                graphql:reply_cast(NameToken, {ok, Name})
                        end),
-            {defer, NameToken};
+            graphql:map(fun({ok, N}) ->
+                                   {ok, <<N/binary, "!">>}
+                           end, {defer, NameToken});
         <<"color">> -> color(Color, Args);
         <<"hitpoints">> ->
             HPToken = graphql:token(Ctx),

--- a/test/dungeon_mutation.erl
+++ b/test/dungeon_mutation.erl
@@ -26,9 +26,13 @@ execute(_Ctx, _, <<"introduceMonster">>, #{ <<"input">> := Input }) ->
         false ->
             exit({bad_mood_value, M})
     end,
+    PlushFactor = case PF of
+                      null -> 0.01;
+                      PlushValue when is_float(PlushValue) -> PlushValue
+                  end,
     {atomic, Monster} = dungeon:insert(#monster {
     	properties = Props,
-    	plush_factor = PF,
+    	plush_factor = PlushFactor,
     	stats = Ss,
     	name = N,
     	color = C,

--- a/test/dungeon_scalar.erl
+++ b/test/dungeon_scalar.erl
@@ -20,8 +20,8 @@ input(<<"Color">>, X) ->
 output(<<"ColorType">>, X) ->
     {ok, X};
 output(<<"Color">>, #{ r := R, g := G, b := B}) ->
-    R1 = integer_to_binary(R, 16),
-    G1 = integer_to_binary(G, 16),
-    B1 = integer_to_binary(B, 16),
+    R1 = integer_to_binary(round(R), 16),
+    G1 = integer_to_binary(round(G), 16),
+    B1 = integer_to_binary(round(B), 16),
     {ok, <<"#", R1/binary, G1/binary, B1/binary>>}.
 


### PR DESCRIPTION
Bool type definition:
> Boolean values, either given as the *true* and *false* values of JSON, or as the strings \"true\" and \"false\".

JSON  *true* and *false* are fine. but strings  \"true\" and \"false\" occur error now.

I fix it up